### PR TITLE
fix: list all apps for a developer to select from

### DIFF
--- a/packages/sdk/src/client/common/contract/caller.ts
+++ b/packages/sdk/src/client/common/contract/caller.ts
@@ -773,6 +773,45 @@ export async function getAppsByDeveloper(
 }
 
 /**
+ * Fetch all apps by a developer by auto-pagination
+ */
+export async function getAllAppsByDeveloper(
+  rpcUrl: string,
+  env: EnvironmentConfig,
+  developer: Address,
+  pageSize: bigint = 100n
+): Promise<{ apps: Address[]; appConfigs: AppConfig[] }> {
+
+  let offset = 0n;
+  const allApps: Address[] = [];
+  const allConfigs: AppConfig[] = [];
+
+  while (true) {
+    const { apps, appConfigs } = await getAppsByDeveloper(
+      rpcUrl,
+      env,
+      developer,
+      offset,
+      pageSize
+    );
+
+    if (apps.length === 0) break;
+
+    allApps.push(...apps);
+    allConfigs.push(...appConfigs);
+
+    if (apps.length < Number(pageSize)) break;
+
+    offset += pageSize;
+  }
+
+  return {
+    apps: allApps,
+    appConfigs: allConfigs,
+  };
+}
+
+/**
  * Suspend apps for an account
  */
 export async function suspend(

--- a/packages/sdk/src/client/common/registry/appNames.ts
+++ b/packages/sdk/src/client/common/registry/appNames.ts
@@ -132,7 +132,7 @@ export async function setAppName(
 
   // Find and remove any existing names for this app ID
   for (const [name, app] of Object.entries(registry.apps)) {
-    if (app.app_id.toLowerCase() === targetAppIDLower) {
+    if (app?.app_id?.toLowerCase() === targetAppIDLower) {
       delete registry.apps[name];
     }
   }
@@ -163,7 +163,7 @@ export function getAppName(environment: string, appID: string): string {
 
   // Search for the app ID in the registry
   for (const [name, app] of Object.entries(registry.apps)) {
-    if (app.app_id.toLowerCase() === normalizedAppID) {
+    if (app?.app_id?.toLowerCase() === normalizedAppID) {
       return name;
     }
   }

--- a/packages/sdk/src/client/common/utils/prompts.ts
+++ b/packages/sdk/src/client/common/utils/prompts.ts
@@ -10,7 +10,7 @@ import { Address, isAddress } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { listApps, getAppName } from "../registry/appNames";
 import { getEnvironmentConfig } from "../config/environment";
-import { getAppsByDeveloper } from "../contract/caller";
+import { getAllAppsByDeveloper } from "../contract/caller";
 import { UserApiClient } from "./userapi";
 
 /**
@@ -389,12 +389,10 @@ async function getAppIDInteractive(
   const developerAddr = account.address;
 
   // Query contract for apps
-  const { apps, appConfigs } = await getAppsByDeveloper(
+  const { apps, appConfigs } = await getAllAppsByDeveloper(
     options.rpcUrl,
     environmentConfig,
     developerAddr,
-    0n,
-    50n,
   );
 
   if (apps.length === 0) {


### PR DESCRIPTION
This PR ensures we list all apps relevant to a developer and ensures any locally stored malformed apps do not break the comparison when searching for the `targetApp`.