### PR TITLE
fix: ensure dev cli uses dev sdk

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "tsup";
 
 // Get BUILD_TYPE from environment, default to 'prod'
 const buildType = process.env.BUILD_TYPE?.toLowerCase() || "prod";
+// Determine SDK package name based on build type for import rewriting
+const sdkPackageName = buildType === "dev" 
+  ? "@layr-labs/ecloud-sdk-dev" 
+  : "@layr-labs/ecloud-sdk";
 
 export default defineConfig({
   entry: ["src/commands/**/*.ts"],
@@ -19,5 +23,10 @@ export default defineConfig({
   esbuildOptions(options) {
     options.outbase = "src";
     options.entryNames = "[dir]/[name]";
+    // Rewrite @layr-labs/ecloud-sdk imports to the correct package name based on build type
+    // This ensures dev builds import from @layr-labs/ecloud-sdk-dev and prod from @layr-labs/ecloud-sdk
+    options.alias = {
+      "@layr-labs/ecloud-sdk": sdkPackageName,
+    };
   },
 });


### PR DESCRIPTION
This PR adds an alias to ensure the dev `cli` uses the dev `sdk`