### PR TITLE
feat: align publish workflows with tagging strategy

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -16,6 +16,17 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Enforce dev tag format
+        run: |
+          VERSION="${{ github.ref_name }}"
+
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-dev ]]; then
+            echo "Version '$VERSION' does not match required pattern v<major>.<minor>.<patch>-dev*"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -23,10 +34,8 @@ jobs:
 
       - name: Set version from tag
         run: |
-          VERSION="${{ github.ref_name }}"
-          # Ensure version has -dev suffix (remove any existing -dev* and add clean -dev)
-          BASE_VERSION="${VERSION%-dev*}"
-          PACKAGE_VERSION="${BASE_VERSION}-dev"
+          # Clean leading v from provided version
+          PACKAGE_VERSION="${VERSION#v}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo "Building dev version: $PACKAGE_VERSION"
@@ -44,7 +53,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        working-directory: ./
+        working-directory: .
         run: pnpm install --frozen-lockfile
 
       - name: Build SDK (dev) - dependency for CLI
@@ -64,8 +73,7 @@ jobs:
       - name: Update SDK package.json for publishing
         working-directory: ./packages/sdk
         run: |
-          # Update SDK package name to dev namespace for publishing
-          npm pkg set name="@layr-labs/ecloud-sdk-dev"
+          # Update version (keep default package name)
           npm pkg set version="${{ env.PACKAGE_VERSION }}"
 
       - name: Publish SDK to npm (dev)
@@ -78,15 +86,13 @@ jobs:
       - name: Update CLI package.json for dev namespace
         working-directory: ./packages/cli
         run: |
-          # Update package name to dev namespace
-          npm pkg set name="@layr-labs/ecloud-cli-dev"
+          # Update version to tag as dev
           npm pkg set version="${{ env.PACKAGE_VERSION }}"
-          # Update SDK dependency to use published dev version
-          npm pkg set "dependencies.@layr-labs/ecloud-sdk-dev"="${{ env.PACKAGE_VERSION }}"
-          npm pkg delete 'dependencies.@layr-labs/ecloud-sdk' || true
+          # Update SDK dependency to match published version
+          npm pkg set "dependencies.@layr-labs/ecloud-sdk"="${{ env.PACKAGE_VERSION }}"
           # Verify changes
           cat package.json | grep -A 2 '"name"'
-          cat package.json | grep -A 1 '"@layr-labs/ecloud'
+          cat package.json | grep -A 1 '"@layr-labs/ecloud-sdk"'
 
       - name: Publish CLI to npm (dev)
         working-directory: ./packages/cli
@@ -98,8 +104,8 @@ jobs:
       - name: Summary
         run: |
           echo "✅ Dev release published successfully!"
-          echo "📦 SDK Package: @layr-labs/ecloud-sdk-dev@${{ env.PACKAGE_VERSION }}"
-          echo "📦 CLI Package: @layr-labs/ecloud-cli-dev@${{ env.PACKAGE_VERSION }}"
+          echo "📦 SDK Package: @layr-labs/ecloud-sdk@${{ env.PACKAGE_VERSION }} (tag: dev)"
+          echo "📦 CLI Package: @layr-labs/ecloud-cli@${{ env.PACKAGE_VERSION }} (tag: dev)"
           echo "🏷️  Tag: dev"
-          echo "🔗 Install with: npm install -g @layr-labs/ecloud-cli-dev@${{ env.PACKAGE_VERSION }}"
+          echo "🔗 Install with: npm install -g @layr-labs/ecloud-cli@dev"
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -25,9 +25,12 @@ jobs:
       - name: Set version from tag
         run: |
           VERSION="${{ github.ref_name }}"
-          # Remove any -dev suffix for production version
-          PACKAGE_VERSION="${VERSION%-dev*}"
-          DEV_VERSION_PREFIX="$PACKAGE_VERSION-dev"
+          # Clean leading v from provided version
+          PACKAGE_VERSION="${VERSION#v}"
+          BASE_VERSION="${VERSION%%-*}"
+          TAG_VERSION="${VERSION#"$BASE_VERSION"}"
+          # Insert dev after the base and before the tag
+          DEV_VERSION_PREFIX="${BASE_VERSION}-dev${TAG_VERSION}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo "DEV_VERSION_PREFIX=$DEV_VERSION_PREFIX" >> $GITHUB_ENV
@@ -112,8 +115,7 @@ jobs:
       - name: Update SDK package.json for publishing
         working-directory: ./packages/sdk
         run: |
-          # Ensure SDK package name is prod namespace (default)
-          npm pkg set name="@layr-labs/ecloud-sdk"
+          # Update version (keep default package name)
           npm pkg set version="${{ env.PACKAGE_VERSION }}"
 
       - name: Publish SDK to npm (prod)
@@ -123,18 +125,16 @@ jobs:
         run: |
           npm publish --tag latest --access public
 
-      - name: Update CLI package.json for prod namespace
+      - name: Update CLI package.json for publishing
         working-directory: ./packages/cli
         run: |
-          # Ensure package name is prod namespace (default)
-          npm pkg set name="@layr-labs/ecloud-cli"
+          # Update version (keep default package name)
           npm pkg set version="${{ env.PACKAGE_VERSION }}"
-          # Update SDK dependency to use published prod version
+          # Update SDK dependency to match published version
           npm pkg set "dependencies.@layr-labs/ecloud-sdk"="${{ env.PACKAGE_VERSION }}"
-          npm pkg delete 'dependencies.@layr-labs/ecloud-sdk-dev' || true
           # Verify changes
           cat package.json | grep -A 2 '"name"'
-          cat package.json | grep -A 1 '"@layr-labs/ecloud'
+          cat package.json | grep -A 1 '"@layr-labs/ecloud-sdk"'
 
       - name: Publish CLI to npm (prod)
         working-directory: ./packages/cli
@@ -146,9 +146,9 @@ jobs:
       - name: Summary
         run: |
           echo "🚀 Production release published successfully!"
-          echo "📦 SDK Package: @layr-labs/ecloud-sdk@${{ env.PACKAGE_VERSION }}"
-          echo "📦 CLI Package: @layr-labs/ecloud-cli@${{ env.PACKAGE_VERSION }}"
+          echo "📦 SDK Package: @layr-labs/ecloud-sdk@${{ env.PACKAGE_VERSION }} (tag: latest)"
+          echo "📦 CLI Package: @layr-labs/ecloud-cli@${{ env.PACKAGE_VERSION }} (tag: latest)"
           echo "🏷️  Tag: latest"
           echo "🔒 Verified dev testing completed with matching commit from ${{ env.VERIFIED_DEV_TAG }}"
-          echo "🔗 Install with: npm install -g @layr-labs/ecloud-cli@${{ env.PACKAGE_VERSION }}"
+          echo "🔗 Install with: npm install -g @layr-labs/ecloud-cli@latest"
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@layr-labs/ecloud-cli",
+  "version": "0.0.1-rfc.1",
   "type": "module",
+  "files": [
+    "dist",
+    "bin",
+    "README.md"
+  ],
   "bin": {
     "ecloud": "./bin/run.js"
   },
@@ -23,6 +29,7 @@
   "scripts": {
     "build": "tsup && npm run build:copy-templates",
     "build:copy-templates": "node scripts/copy-templates.js",
+    "prepublishOnly": "cp ../../README.md .",
     "lint": "eslint .",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@layr-labs/ecloud-sdk",
-  "version": "0.0.1",
+  "version": "0.0.1-rfc.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -15,7 +19,7 @@
   "scripts": {
     "build": "tsup && npm run build:copy-templates",
     "build:copy-templates": "node scripts/copy-templates.js",
-    "test:build-type": "node test-build-type.js",
+    "prepublishOnly": "cp ../../README.md .",
     "lint": "eslint .",
     "format": "prettier --check .",
     "format:fix": "prettier --write ."

--- a/packages/sdk/src/client/common/auth/keyring.ts
+++ b/packages/sdk/src/client/common/auth/keyring.ts
@@ -68,12 +68,12 @@ export async function storePrivateKey(privateKey: string): Promise<void> {
  * Note: Returns the single stored key for all environments.
  * The environment parameter is kept for API compatibility but is ignored.
  */
-export async function getPrivateKey(): Promise<string | null> {
+export async function getPrivateKey(): Promise<`0x${string}` | null> {
   const entry = new AsyncEntry(SERVICE_NAME, ACCOUNT_NAME);
   try {
     const key = await entry.getPassword();
     if (key && validatePrivateKey(key)) {
-      return key;
+      return key as `0x${string}`;
     }
   } catch {
     // Key not found

--- a/packages/sdk/src/client/common/auth/resolver.ts
+++ b/packages/sdk/src/client/common/auth/resolver.ts
@@ -10,7 +10,7 @@
 import { getPrivateKey, validatePrivateKey } from "./keyring";
 
 export interface PrivateKeySource {
-  key: string;
+  key: `0x${string}`;
   source: string;
 }
 
@@ -35,13 +35,13 @@ export async function getPrivateKeyWithSource(options: {
       );
     }
     return {
-      key: options.privateKey,
+      key: options.privateKey as `0x${string}`,
       source: "command flag",
     };
   }
 
   // 2. Check environment variable
-  const envKey = process.env.ECLOUD_PRIVATE_KEY;
+  const envKey = process.env.ECLOUD_PRIVATE_KEY as `0x${string}`;
   if (envKey) {
     if (!validatePrivateKey(envKey)) {
       throw new Error(


### PR DESCRIPTION
This PR aligns the publish workflows with our tagging strategy.

Dev tags must follow the format `^v[0-9]+\.[0-9]+\.[0-9]+-dev*`:

```
v0.0.1-dev
v0.0.1-dev-rfc.1
...
```

This is to ensure we can enforce dev testing prior to prod publishing.