### PR TITLE
Potential fix for code scanning alert no. 19: Unsafe shell command constructed from library input

### DIFF
--- a/packages/sdk/src/client/common/templates/git.ts
+++ b/packages/sdk/src/client/common/templates/git.ts
@@ -7,11 +7,12 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { exec } from "child_process";
+import { exec, execFile } from "child_process";
 import { promisify } from "util";
 import { Logger } from "../types";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export interface GitFetcherConfig {
   verbose: boolean;
@@ -43,7 +44,11 @@ export async function fetchTemplate(
     );
 
     // Checkout the desired ref
-    await execAsync(`git -C ${targetDir} checkout --quiet ${ref}`);
+    await execFileAsync(
+      "git",
+      ["-C", targetDir, "checkout", "--quiet", ref],
+      { maxBuffer: 10 * 1024 * 1024 },
+    );
 
     // Update submodules
     await execAsync(
@@ -121,22 +126,22 @@ async function cloneSparse(
 ): Promise<void> {
   try {
     // Initialize git repository
-    await execAsync(`git init ${tempDir}`);
+    await execFileAsync("git", ["init", tempDir]);
 
     // Add remote
-    await execAsync(`git -C ${tempDir} remote add origin ${repoURL}`);
+    await execFileAsync("git", ["-C", tempDir, "remote", "add", "origin", repoURL]);
 
     // Enable sparse checkout
-    await execAsync(`git -C ${tempDir} config core.sparseCheckout true`);
+    await execFileAsync("git", ["-C", tempDir, "config", "core.sparseCheckout", "true"]);
 
     // Set sparse checkout path
     const sparseCheckoutPath = path.join(tempDir, ".git/info/sparse-checkout");
     fs.writeFileSync(sparseCheckoutPath, `${subPath}\n`);
 
     // Fetch and checkout
-    await execAsync(`git -C ${tempDir} fetch origin ${ref}`);
+    await execFileAsync("git", ["-C", tempDir, "fetch", "origin", ref]);
 
-    await execAsync(`git -C ${tempDir} checkout ${ref}`);
+    await execFileAsync("git", ["-C", tempDir, "checkout", ref]);
   } catch (error: any) {
     throw new Error(`Failed to clone sparse repository: ${error.message}`);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/ecloud/security/code-scanning/19](https://github.com/Layr-Labs/ecloud/security/code-scanning/19)

To fix the issue:

- All shell commands that interpolate untrusted values in the form of `${ref}` and similar (including `${repoURL}`, `${subPath}`) should avoid string concatenation and instead use a safer API, such as `execFile` or provide proper quoting with a library like `shell-quote`. 
- However, `git checkout <ref>` and many other `git` operations do not require a shell to interpret pipes/redirections, so **they should be invoked using argument arrays** and `child_process.execFile`.
- Thus, replace vulnerable `execAsync` usages with `execFileAsync`, requiring:
  - Import `execFile` from `child_process`.
  - Add a promisified version `execFileAsync`.
  - Refactor commands like `git -C ${tempDir} checkout ${ref}` to use argument arrays and pass values as elements.
- Any other commands that do require shell interpretation (none in shown code) would need proper quoting using `shell-quote`.

Changes should be made in `packages/sdk/src/client/common/templates/git.ts`:
- Add import and promisified `execFileAsync`.
- Change all relevant `execAsync` calls where untrusted interpolation occurs to their safe counterparts.
- Do this for both the full template repository and the sparse checkout logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
