### PR TITLE
Potential fix for code scanning alert no. 13: Unsafe shell command constructed from library input

### DIFF
--- a/packages/sdk/src/client/common/registry/digest.ts
+++ b/packages/sdk/src/client/common/registry/digest.ts
@@ -9,7 +9,7 @@ import { promisify } from "util";
 import { ImageDigestResult } from "../types";
 import { DOCKER_PLATFORM } from "../constants";
 
-const exec = promisify(child_process.exec);
+const execFile = promisify(child_process.execFile);
 
 interface Platform {
   os: string;
@@ -36,7 +36,7 @@ interface Manifest {
 export async function getImageDigestAndName(imageRef: string): Promise<ImageDigestResult> {
   try {
     // Use docker manifest inspect to get the manifest
-    const { stdout } = await exec(`docker manifest inspect ${imageRef}`, {
+    const { stdout } = await execFile("docker", ["manifest", "inspect", imageRef], {
       maxBuffer: 10 * 1024 * 1024, // 10MB buffer
     });
 
@@ -97,7 +97,7 @@ async function extractDigestFromSinglePlatform(
   // and then inspect the image to get platform info
   try {
     // Use docker inspect to get platform info
-    const { stdout } = await exec(`docker inspect ${imageRef}`, {
+    const { stdout } = await execFile("docker", ["inspect", imageRef], {
       maxBuffer: 10 * 1024 * 1024,
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/ecloud/security/code-scanning/13](https://github.com/Layr-Labs/ecloud/security/code-scanning/13)

To fix the problem:
- Change the vulnerable uses of `child_process.exec` with string concatenation to use `child_process.execFile` where possible. This means passing the command and its arguments as an array to avoid shell interpretation of injected metacharacters.
- For `docker manifest inspect ${imageRef}` and `docker inspect ${imageRef}`, these can be expressed as `["docker", "manifest", "inspect", imageRef]` and `["docker", "inspect", imageRef]` which are perfectly compatible with `execFile`.
- Update the imports to bring in `execFile` and promisify it.
- Adjust code that parses `stdout` to use the result from `execFile`.
- Make sure all variants (both in `getImageDigestAndName` and `extractDigestFromSinglePlatform`) are updated.
- Only modify the snippets and files provided, leaving interfaces and non-relevant code unchanged.
- No new npm dependencies required, just standard Node.js libraries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
