### PR TITLE
Potential fix for code scanning alert no. 29: Unsafe shell command constructed from library input

### DIFF
--- a/packages/sdk/src/client/common/templates/git.ts
+++ b/packages/sdk/src/client/common/templates/git.ts
@@ -46,7 +46,11 @@ export async function fetchTemplate(
     });
 
     // Update submodules
-    await execAsync(`git -C ${targetDir} submodule update --init --recursive --progress`);
+    await execFileAsync(
+      "git",
+      ["-C", targetDir, "submodule", "update", "--init", "--recursive", "--progress"],
+      { maxBuffer: 10 * 1024 * 1024 }
+    );
 
     logger.info(`Clone repo complete: ${repoURL}\n`);
   } catch (error: any) {


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/ecloud/security/code-scanning/29](https://github.com/Layr-Labs/ecloud/security/code-scanning/29)

**General approach:**  
To fix this, ensure that untrusted or user-derived inputs are never directly interpolated into a command string executed via the shell. Instead, use subprocess APIs that avoid the shell (`execFile` or pass arguments as arrays).

**Best way to fix for this specific case:**  
- Replace the `execAsync` call at line 49 which currently runs a shell command with interpolation, with a call to `execFileAsync` instead.
- Construct the command and its arguments as separate parameters (i.e., `['-C', targetDir, 'submodule', 'update', '--init', '--recursive', '--progress']`), which removes the need for the shell to parse/interpolate any arguments.
- No functional change occurs to the user's intent, but you prevent command injection.
- Also, for completeness, the similar command at line 39 (`git clone --no-checkout --progress ...`) should also be fixed in the same way, since it too interpolates user data, although not directly flagged in the prompt for this alert, but clearly the same risk.

**What to change:**  
- File: `packages/sdk/src/client/common/templates/git.ts`
- Change the call on line 49 from `execAsync` with a string (shell command) to `execFileAsync` with positional arguments as array.
- (Optionally, fix similar usage on line 39 for completeness and defense-in-depth, but strictly speaking, only line 49 is in scope for this alert.)

**What is needed:**  
- No new imports are needed—`execFileAsync` is already imported and defined.
- The array of arguments should map to the intended git command.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
