### PR TITLE
Potential fix for code scanning alert no. 11: Unsafe shell command constructed from library input

### DIFF
--- a/packages/sdk/src/client/common/docker/push.ts
+++ b/packages/sdk/src/client/common/docker/push.ts
@@ -9,10 +9,11 @@ import * as os from "os";
 import * as path from "path";
 import * as child_process from "child_process";
 
-import { exec } from "child_process";
+import { exec, execFile } from "child_process";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Extract hostname from a registry URL/string for safe comparison
@@ -247,7 +248,7 @@ async function verifyImageExists(
 
   while (retries > 0) {
     try {
-      await execAsync(`docker manifest inspect ${imageRef}`, {
+      await execFileAsync("docker", ["manifest", "inspect", imageRef], {
         maxBuffer: 10 * 1024 * 1024,
         timeout: 10000, // 10 second timeout
       });


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/ecloud/security/code-scanning/11](https://github.com/Layr-Labs/ecloud/security/code-scanning/11)

To mitigate the possibility of shell injection or command misbehavior, the best way to fix this is to avoid constructing the shell command via string concatenation with user/library input. Instead, pass command arguments as arrays to APIs that do not invoke a shell (such as `child_process.execFile`). In the case that shell features (such as pipes or redirects) are required, inputs must be safely escaped using a library such as `shell-quote`.  
For the case in question (`verifyImageExists` using `execAsync` to run `docker manifest inspect ${imageRef}`), we should replace it with `execFileAsync`, passing the command and arguments as an array so the `imageRef` is not interpreted by the shell.  
This requires us to define an appropriate async wrapper around `execFile` (e.g., using `promisify` as with `exec`), and update the usage to pass command and args accordingly.  
Edits are limited to `packages/sdk/src/client/common/docker/push.ts` in the region where `execAsync` is invoked for `docker manifest inspect ${imageRef}`.  
Required changes:  
- Add promisified wrapper for `execFile` (e.g., `execFileAsync`)  
- Replace uses of `execAsync` here with `execFileAsync`, passing command as `docker`, then an array of args (`["manifest", "inspect", imageRef]`), and options  
- Wherever `execAsync` could receive tainted input, ensure argument arrays rather than concatenated strings are used


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
