### PR TITLE
feat: add correct client version to user api

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -60,6 +60,7 @@ jobs:
         working-directory: ./packages/sdk
         env:
           BUILD_TYPE: dev
+          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
         run: |
           pnpm run build
 
@@ -67,6 +68,7 @@ jobs:
         working-directory: ./packages/cli
         env:
           BUILD_TYPE: dev
+          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
         run: |
           pnpm run build
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -102,6 +102,7 @@ jobs:
         working-directory: ./packages/sdk
         env:
           BUILD_TYPE: prod
+          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
         run: |
           pnpm run build
 
@@ -109,6 +110,7 @@ jobs:
         working-directory: ./packages/cli
         env:
           BUILD_TYPE: prod
+          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
         run: |
           pnpm run build
 

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -23,6 +23,7 @@ import {
   getPrivateKeyInteractive,
 } from "../../../utils/prompts";
 import { invalidateProfileCache } from "../../../utils/globalConfig";
+import { getClientId } from "../../../utils/version";
 import chalk from "chalk";
 
 export default class AppDeploy extends Command {
@@ -226,7 +227,12 @@ export default class AppDeploy extends Command {
         // Upload profile if provided (non-blocking - warn on failure but don't fail deployment)
         logger.info("Uploading app profile...");
         try {
-          const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl);
+          const userApiClient = new UserApiClient(
+            environmentConfig,
+            privateKey,
+            rpcUrl,
+            getClientId(),
+          );
           await userApiClient.uploadAppProfile(
             res.appId as `0x${string}`,
             profile.name,
@@ -267,7 +273,7 @@ async function fetchAvailableInstanceTypes(
   rpcUrl?: string,
 ): Promise<Array<{ sku: string; description: string }>> {
   try {
-    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl);
+    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl, getClientId());
 
     const skuList = await userApiClient.getSKUs();
     if (skuList.skus.length === 0) {

--- a/packages/cli/src/commands/compute/app/info.ts
+++ b/packages/cli/src/commands/compute/app/info.ts
@@ -8,6 +8,7 @@ import {
 import { commonFlags, validateCommonFlags } from "../../../flags";
 import { getOrPromptAppID } from "../../../utils/prompts";
 import { formatAppDisplay, printAppDisplay } from "../../../utils/format";
+import { getClientId } from "../../../utils/version";
 import { Address } from "viem";
 import chalk from "chalk";
 
@@ -56,7 +57,7 @@ export default class AppInfo extends Command {
     });
 
     // Create UserAPI client
-    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl);
+    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl, getClientId());
 
     if (flags.watch) {
       await this.watchMode(appID, userApiClient, rpcUrl, environmentConfig, flags["address-count"]);

--- a/packages/cli/src/commands/compute/app/list.ts
+++ b/packages/cli/src/commands/compute/app/list.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../utils/prompts";
 import { getAppInfosChunked } from "../../../utils/appResolver";
 import { formatAppDisplay, printAppDisplay } from "../../../utils/format";
+import { getClientId } from "../../../utils/version";
 import chalk from "chalk";
 
 export default class AppList extends Command {
@@ -88,7 +89,7 @@ export default class AppList extends Command {
     }
 
     // Create UserAPI client to get additional info
-    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl);
+    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl, getClientId());
 
     // Fetch all data in parallel
     const addressCount = flags["address-count"];

--- a/packages/cli/src/commands/compute/app/profile/set.ts
+++ b/packages/cli/src/commands/compute/app/profile/set.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../../utils/prompts";
 import { createAppResolver } from "../../../../utils/appResolver";
 import { invalidateProfileCache } from "../../../../utils/globalConfig";
+import { getClientId } from "../../../../utils/version";
 import chalk from "chalk";
 
 export default class ProfileSet extends Command {
@@ -110,7 +111,7 @@ export default class ProfileSet extends Command {
     // Upload profile via API
     this.log("\nUploading app profile...");
 
-    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl);
+    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl, getClientId());
 
     try {
       const response = await userApiClient.uploadAppProfile(

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -21,6 +21,7 @@ import {
   confirm,
   getPrivateKeyInteractive,
 } from "../../../utils/prompts";
+import { getClientId } from "../../../utils/version";
 import chalk from "chalk";
 
 export default class AppUpgrade extends Command {
@@ -111,7 +112,7 @@ export default class AppUpgrade extends Command {
     // 5. Get current instance type (best-effort, used as default)
     let currentInstanceType = "";
     try {
-      const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl);
+      const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl, getClientId());
       const infos = await userApiClient.getInfos([appID], 1);
       if (infos.length > 0) {
         currentInstanceType = infos[0].machineType || "";
@@ -200,7 +201,7 @@ async function fetchAvailableInstanceTypes(
   rpcUrl?: string,
 ): Promise<Array<{ sku: string; description: string }>> {
   try {
-    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl);
+    const userApiClient = new UserApiClient(environmentConfig, privateKey, rpcUrl, getClientId());
 
     const skuList = await userApiClient.getSKUs();
     if (skuList.skus.length === 0) {

--- a/packages/cli/src/utils/appResolver.ts
+++ b/packages/cli/src/utils/appResolver.ts
@@ -22,6 +22,7 @@ import {
   getAppName as getLocalAppName,
   resolveAppIDFromRegistry,
 } from "./appNames";
+import { getClientId } from "./version";
 
 const CHUNK_SIZE = 10;
 
@@ -234,7 +235,12 @@ export class AppResolver {
       }
 
       // Fetch info for all apps to get profile names
-      const userApiClient = new UserApiClient(this.environmentConfig, this.privateKey, this.rpcUrl);
+      const userApiClient = new UserApiClient(
+        this.environmentConfig,
+        this.privateKey,
+        this.rpcUrl,
+        getClientId(),
+      );
       const appInfos = await getAppInfosChunked(userApiClient, apps);
 
       // Build profile names map

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -30,6 +30,7 @@ import {
 import { getAppInfosChunked } from "./appResolver";
 import { getDefaultEnvironment, getProfileCache, setProfileCache } from "./globalConfig";
 import { listApps, isAppNameAvailable, findAvailableName } from "./appNames";
+import { getClientId } from "./version";
 
 // Helper to add hex prefix
 function addHexPrefix(value: string): `0x${string}` {
@@ -799,6 +800,7 @@ async function getAppIDInteractive(options: GetAppIDOptions): Promise<Address> {
         environmentConfig,
         options.privateKey,
         options.rpcUrl,
+        getClientId(),
       );
       const appInfos = await getAppInfosChunked(userApiClient, apps);
 

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -1,0 +1,23 @@
+/**
+ * CLI version utilities
+ *
+ * CLI_VERSION_BUILD_TIME is replaced at build time by tsup's define option
+ */
+
+// @ts-ignore - CLI_VERSION_BUILD_TIME is injected at build time by tsup
+declare const CLI_VERSION_BUILD_TIME: string | undefined;
+
+/**
+ * Get the CLI version
+ */
+export function getCliVersion(): string {
+  // @ts-ignore - CLI_VERSION_BUILD_TIME is injected at build time
+  return typeof CLI_VERSION_BUILD_TIME !== "undefined" ? CLI_VERSION_BUILD_TIME : "0.0.0";
+}
+
+/**
+ * Get the x-client-id header value for API calls
+ */
+export function getClientId(): string {
+  return `ecloud-cli/v${getCliVersion()}`;
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from "tsup";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 
 // Get BUILD_TYPE from environment, default to 'prod'
 const buildType = process.env.BUILD_TYPE?.toLowerCase() || "prod";
+
+// Get version: prefer PACKAGE_VERSION env var (set by CI from git tag), fallback to package.json
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8"));
+const cliVersion = process.env.PACKAGE_VERSION || packageJson.version || "0.0.0";
 
 export default defineConfig({
   entry: ["src/commands/**/*.ts"],
@@ -15,6 +23,7 @@ export default defineConfig({
   banner: { js: "#!/usr/bin/env node" },
   define: {
     BUILD_TYPE_BUILD_TIME: JSON.stringify(buildType),
+    CLI_VERSION_BUILD_TIME: JSON.stringify(cliVersion),
   },
   loader: {
     ".tmpl": "text",

--- a/packages/sdk/src/client/common/registry/digest.ts
+++ b/packages/sdk/src/client/common/registry/digest.ts
@@ -39,7 +39,7 @@ export async function getImageDigestAndName(imageRef: string): Promise<ImageDige
     const { stdout } = await execFileAsync(
       "docker",
       ["manifest", "inspect", imageRef],
-      { maxBuffer: 10 * 1024 * 1024 } // 10MB buffer
+      { maxBuffer: 10 * 1024 * 1024 }, // 10MB buffer
     );
 
     const manifest: Manifest = JSON.parse(stdout);

--- a/packages/sdk/src/client/common/templates/git.ts
+++ b/packages/sdk/src/client/common/templates/git.ts
@@ -49,7 +49,7 @@ export async function fetchTemplate(
     await execFileAsync(
       "git",
       ["-C", targetDir, "submodule", "update", "--init", "--recursive", "--progress"],
-      { maxBuffer: 10 * 1024 * 1024 }
+      { maxBuffer: 10 * 1024 * 1024 },
     );
 
     logger.info(`Clone repo complete: ${repoURL}\n`);

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from "tsup";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 
 // Get BUILD_TYPE from environment, default to 'prod'
 const buildType = process.env.BUILD_TYPE?.toLowerCase() || "prod";
+
+// Get version: prefer PACKAGE_VERSION env var (set by CI from git tag), fallback to package.json
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8"));
+const sdkVersion = process.env.PACKAGE_VERSION || packageJson.version || "0.0.0";
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -11,6 +19,7 @@ export default defineConfig({
   sourcemap: true,
   define: {
     BUILD_TYPE_BUILD_TIME: JSON.stringify(buildType),
+    SDK_VERSION_BUILD_TIME: JSON.stringify(sdkVersion),
   },
   loader: {
     ".tmpl": "text",


### PR DESCRIPTION
This feature makes sure if it's called from CLI, I have client ID as CLI, but if it's somebody directly using our SDK, it shows SDK client version. 