### PR TITLE
chore: update to have simpler prod pipeline

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -27,33 +27,31 @@ jobs:
           VERSION="${{ github.ref_name }}"
           # Clean leading v from provided version
           PACKAGE_VERSION="${VERSION#v}"
+          # Extract base semantic version (x.y.z) - strip everything after first hyphen
           BASE_VERSION="${VERSION%%-*}"
-          TAG_VERSION="${VERSION#"$BASE_VERSION"}"
-          # Insert dev after the base and before the tag
-          DEV_VERSION_PREFIX="${BASE_VERSION}-dev${TAG_VERSION}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
-          echo "DEV_VERSION_PREFIX=$DEV_VERSION_PREFIX" >> $GITHUB_ENV
+          echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_ENV
           echo "Building production version: $PACKAGE_VERSION"
-          echo "Will verify dev tag exists: $DEV_VERSION_PREFIX"
+          echo "Will verify dev tag exists for base version: $BASE_VERSION"
 
       - name: Verify dev testing occurred
         run: |
-          echo "Looking for dev tag with prefix: ${{ env.DEV_VERSION_PREFIX }}"
+          echo "Looking for dev tag with base version: ${{ env.BASE_VERSION }}"
 
-          # Check if dev tag exists (with or without suffix)
-          DEV_TAGS=$(git tag -l "${DEV_VERSION_PREFIX}*" | head -10)
+          # Check if any dev tag exists for this semantic version (e.g., v0.1.0-dev*)
+          DEV_TAGS=$(git tag -l "${{ env.BASE_VERSION }}-dev*" | head -10)
           if [ -z "$DEV_TAGS" ]; then
-            echo "ERROR: No dev tag found with prefix ${DEV_VERSION_PREFIX}"
+            echo "ERROR: No dev tag found for version ${{ env.BASE_VERSION }}"
             echo ""
             echo "Available dev tags:"
             git tag -l "*-dev*" | head -10 || echo "No dev tags found"
             echo ""
-            echo "Must test in dev first: git tag ${DEV_VERSION_PREFIX} or ${DEV_VERSION_PREFIX}.1"
+            echo "Must test in dev first: git tag ${{ env.BASE_VERSION }}-dev"
             exit 1
           fi
 
-          echo "✅ Found dev tags:"
+          echo "✅ Found dev tags for ${{ env.BASE_VERSION }}:"
           echo "$DEV_TAGS"
 
           # Verify dev and prod tags point to same commit
@@ -79,7 +77,7 @@ jobs:
             echo "  $DEV_TAG: $DEV_COMMIT"
           done
           echo ""
-          echo "Create a dev tag on the same commit: git tag ${DEV_VERSION_PREFIX} $PROD_COMMIT"
+          echo "Create a dev tag on the same commit: git tag ${{ env.BASE_VERSION }}-dev $PROD_COMMIT"
           exit 1
 
       - name: Setup pnpm


### PR DESCRIPTION
I simplified the logic to check for dev tags based on just the semantic version (x.y.z). Here's what changed:
Before:
	For prod tag `v0.1.0-rc.1` → looked for `v0.1.0-dev-rc.1*` (too specific)
After:
	For prod tag `v0.1.0-rc.1` → looks for `v0.1.0-dev*` (matches any dev tag for that version)

So now if you have `v0.1.0-dev` in your dev tags, releasing `v0.1.0`, `v0.1.0-rc.1`, or any other variant will work as long as:
* A dev tag like `v0.1.0-dev`, `v0.1.0-dev.1`, etc. exists
* The dev tag points to the same commit as the prod tag


This matches your available dev tags:
* `v0.1.0-dev` ✅ will now be found when releasing `v0.1.0-rc.1`