### PR TITLE
feat: add isDelegated check before undelegate operation

### DIFF
--- a/packages/cli/src/commands/compute/undelegate.ts
+++ b/packages/cli/src/commands/compute/undelegate.ts
@@ -20,6 +20,13 @@ export default class Undelegate extends Command {
     const { flags } = await this.parse(Undelegate);
     const app = await createAppClient(flags);
 
+    // Check if account is currently delegated
+    const isDelegated = await app.isDelegated();
+    if (!isDelegated) {
+      this.log(`\n${chalk.gray(`Account is not currently delegated`)}`);
+      return;
+    }
+
     const res = await app.undelegate();
 
     if (!res.tx) {

--- a/packages/sdk/src/client/common/contract/caller.ts
+++ b/packages/sdk/src/client/common/contract/caller.ts
@@ -5,7 +5,7 @@
  */
 
 import { privateKeyToAccount } from "viem/accounts";
-import { executeBatch } from "./eip7702";
+import { executeBatch, checkERC7702Delegation } from "./eip7702";
 import {
   createWalletClient,
   createPublicClient,
@@ -961,6 +961,33 @@ export async function suspend(
       txDescription: "Suspend",
     },
     logger,
+  );
+}
+
+/**
+ * Check if account is delegated to the ERC-7702 delegator
+ */
+export async function isDelegated(options: {
+  privateKey: string;
+  rpcUrl: string;
+  environmentConfig: EnvironmentConfig;
+}): Promise<boolean> {
+  const { privateKey, rpcUrl, environmentConfig } = options;
+
+  const privateKeyHex = addHexPrefix(privateKey);
+  const account = privateKeyToAccount(privateKeyHex);
+
+  const chain = getChainFromID(environmentConfig.chainID);
+
+  const publicClient = createPublicClient({
+    chain,
+    transport: http(rpcUrl),
+  });
+
+  return checkERC7702Delegation(
+    publicClient,
+    account.address,
+    environmentConfig.erc7702DelegatorAddress as Address,
   );
 }
 

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -84,8 +84,12 @@ export {
   type EstimateGasOptions,
 } from "./common/contract/caller";
 
-// Export batch gas estimation
-export { estimateBatchGas, type EstimateBatchGasOptions } from "./common/contract/eip7702";
+// Export batch gas estimation and delegation check
+export {
+  estimateBatchGas,
+  checkERC7702Delegation,
+  type EstimateBatchGasOptions,
+} from "./common/contract/eip7702";
 
 // Export instance type utilities
 export { getCurrentInstanceType } from "./common/utils/instance";

--- a/packages/sdk/src/client/modules/app/index.ts
+++ b/packages/sdk/src/client/modules/app/index.ts
@@ -9,7 +9,7 @@ import { createApp, CreateAppOpts } from "./create";
 import { logs, LogsOptions } from "./logs";
 
 import { getEnvironmentConfig } from "../../common/config/environment";
-import { sendAndWaitForTransaction, undelegate } from "../../common/contract/caller";
+import { sendAndWaitForTransaction, undelegate, isDelegated } from "../../common/contract/caller";
 
 import type { AppId, DeployAppOpts, LifecycleOpts, UpgradeAppOpts } from "../../common/types";
 import { getLogger, addHexPrefix } from "../../common/utils";
@@ -71,6 +71,7 @@ export interface AppModule {
   start: (appId: AppId, opts?: LifecycleOpts) => Promise<{ tx: `0x${string}` | false }>;
   stop: (appId: AppId, opts?: LifecycleOpts) => Promise<{ tx: `0x${string}` | false }>;
   terminate: (appId: AppId, opts?: LifecycleOpts) => Promise<{ tx: `0x${string}` | false }>;
+  isDelegated: () => Promise<boolean>;
   undelegate: () => Promise<{ tx: `0x${string}` | false }>;
 }
 
@@ -234,6 +235,14 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
         logger,
       );
       return { tx };
+    },
+
+    async isDelegated() {
+      return isDelegated({
+        privateKey,
+        rpcUrl: ctx.rpcUrl,
+        environmentConfig: environment,
+      });
     },
 
     async undelegate() {


### PR DESCRIPTION
Check if account is delegated before attempting to undelegate. Returns early with message if not currently delegated.