### PR TITLE
feat: add smart defaults for docker image reference

### DIFF
--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -16,7 +16,11 @@ import {
   ResourceUsageMonitoring,
   confirm,
 } from "../../../utils/prompts";
-import { invalidateProfileCache, setLinkedAppForDirectory } from "../../../utils/globalConfig";
+import {
+  invalidateProfileCache,
+  setLinkedAppForDirectory,
+  setAppImageRef,
+} from "../../../utils/globalConfig";
 import { getClientId } from "../../../utils/version";
 import chalk from "chalk";
 
@@ -230,8 +234,9 @@ export default class AppDeploy extends Command {
       try {
         const cwd = process.env.INIT_CWD || process.cwd();
         setLinkedAppForDirectory(environment, cwd, res.appId);
+        setAppImageRef(environment, res.appId, res.imageRef);
       } catch (err: any) {
-        logger.debug(`Failed to link directory to app: ${err.message}`);
+        logger.debug(`Failed to save app config: ${err.message}`);
       }
 
       this.log(

--- a/packages/cli/src/utils/globalConfig.ts
+++ b/packages/cli/src/utils/globalConfig.ts
@@ -38,6 +38,11 @@ export interface GlobalConfig {
       [directoryPath: string]: string;
     };
   };
+  app_images?: {
+    [environment: string]: {
+      [appId: string]: string; // appId -> last used image reference
+    };
+  };
 }
 
 // Profile cache TTL: 24 hours in milliseconds
@@ -308,6 +313,42 @@ export function updateProfileCacheEntry(
   const normalizedAppId = appId.toLowerCase();
   config.profile_cache[environment].profiles[normalizedAppId] = profileName;
   config.profile_cache[environment].updated_at = Date.now();
+
+  saveGlobalConfig(config);
+}
+
+// ==================== App Image Functions ====================
+
+/**
+ * Get the last used image reference for an app
+ */
+export function getAppImageRef(environment: string, appId: string): string | null {
+  const config = loadGlobalConfig();
+  const images = config.app_images?.[environment];
+  if (!images) {
+    return null;
+  }
+
+  const normalizedAppId = appId.toLowerCase();
+  return images[normalizedAppId] || null;
+}
+
+/**
+ * Save the image reference used for an app
+ */
+export function setAppImageRef(environment: string, appId: string, imageRef: string): void {
+  const config = loadGlobalConfig();
+
+  if (!config.app_images) {
+    config.app_images = {};
+  }
+
+  if (!config.app_images[environment]) {
+    config.app_images[environment] = {};
+  }
+
+  const normalizedAppId = appId.toLowerCase();
+  config.app_images[environment][normalizedAppId] = imageRef;
 
   saveGlobalConfig(config);
 }


### PR DESCRIPTION
## Summary
- Use authenticated registry + directory name as default when deploying existing images
- Store last used image reference per app in local config (`~/.config/ecloud/config.yaml`)
- Use saved image reference as default for upgrades

## UX

**First deploy** (uses authenticated registry + directory name):
```
? Enter Docker image reference: (gaj/myapp:latest) _
```

**Upgrade** (uses last deployed image):
```
? Enter Docker image reference: (gaj/myapp:latest) _
```