### PR TITLE
feat(cli): add --build-caddyfile flag to deploy and upgrade commands

### DIFF
--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -129,6 +129,12 @@ export default class AppDeploy extends Command {
       description: "Dependency digests for verifiable build (git source mode) (sha256:...)",
       multiple: true,
     }),
+    "build-caddyfile": Flags.string({
+      description:
+        "Optional path to Caddyfile inside the repo (relative to build context). If omitted, auto-detected from env file TLS settings",
+      required: false,
+      env: "ECLOUD_BUILD_CADDYFILE",
+    }),
   };
 
   async run() {
@@ -228,7 +234,7 @@ export default class AppDeploy extends Command {
               repoUrl: flags.repo!,
               gitRef: flags.commit!,
               dockerfilePath: flags["build-dockerfile"],
-              caddyfilePath: undefined,
+              caddyfilePath: flags["build-caddyfile"],
               buildContextPath: flags["build-context"],
               dependencies: flags["build-dependencies"],
             }

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -107,6 +107,12 @@ export default class AppUpgrade extends Command {
       description: "Dependency digests for verifiable build (git source mode) (sha256:...)",
       multiple: true,
     }),
+    "build-caddyfile": Flags.string({
+      description:
+        "Optional path to Caddyfile inside the repo (relative to build context). If omitted, auto-detected from env file TLS settings",
+      required: false,
+      env: "ECLOUD_BUILD_CADDYFILE",
+    }),
   };
 
   async run() {
@@ -188,7 +194,7 @@ export default class AppUpgrade extends Command {
               repoUrl: flags.repo!,
               gitRef: flags.commit!,
               dockerfilePath: flags["build-dockerfile"],
-              caddyfilePath: undefined,
+              caddyfilePath: flags["build-caddyfile"],
               buildContextPath: flags["build-context"],
               dependencies: flags["build-dependencies"],
             }


### PR DESCRIPTION
## Summary
- Adds `--build-caddyfile` flag to `ecloud compute app deploy --verifiable` and `ecloud compute app upgrade --verifiable`
- The flag was already available on `ecloud compute build submit` but was missing from the deploy/upgrade commands
- This enables CI workflows to specify the Caddyfile path explicitly rather than relying on auto-detection from env file TLS settings

## Test plan
- [ ] Run `ecloud compute app upgrade --help` and verify `--build-caddyfile` flag appears
- [ ] Run `ecloud compute app deploy --help` and verify `--build-caddyfile` flag appears
- [ ] Test verifiable build with `--build-caddyfile Caddyfile` flag in CI context

🤖 Generated with [Claude Code](https://claude.com/claude-code)