### PR TITLE
fix: make billing client chain-agnostic 

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -78,7 +78,7 @@ export async function createBuildClient(flags: CommonFlags) {
   flags = await validateCommonFlags(flags, { requirePrivateKey: false });
 
   // Get environment config for RPC URL
-  const environment = flags.environment || "mainnet-alpha";
+  const environment = flags.environment;
   const environmentConfig = getEnvironmentConfig(environment);
   const rpcUrl = flags["rpc-url"] || environmentConfig.defaultRPCURL;
 


### PR DESCRIPTION
The billing client was unnecessarily requiring an environment/RPC configuration, causing errors when the environment defaulted to an invalid value. Since billing authentication uses EIP-712 signatures without a chainId in the domain, it's inherently chain-agnostic. The wallet client now uses a custom transport for local signing only.