### PR TITLE
feat: add strict Node.js version compatibility checks

### DIFF
--- a/packages/cli/bin/dev.js
+++ b/packages/cli/bin/dev.js
@@ -1,5 +1,17 @@
 #!/usr/bin/env -S node --loader ts-node/esm --disable-warning=ExperimentalWarning
 
-import { execute } from "@oclif/core";
+const MIN_NODE_MAJOR = 18;
+const currentVersion = process.versions.node;
+const currentMajor = parseInt(currentVersion.split(".")[0], 10);
+
+if (currentMajor < MIN_NODE_MAJOR) {
+  console.error(
+    `\nError: ecloud requires Node.js v${MIN_NODE_MAJOR} or later, but you are running v${currentVersion}.\n` +
+      `Please upgrade Node.js: https://nodejs.org/\n`,
+  );
+  process.exit(1);
+}
+
+const { execute } = await import("@oclif/core");
 
 await execute({ development: true, dir: import.meta.url });

--- a/packages/cli/bin/run.js
+++ b/packages/cli/bin/run.js
@@ -1,5 +1,20 @@
 #!/usr/bin/env node
 
-import { execute } from "@oclif/core";
+// Preflight: check Node.js version before loading dependencies.
+// Without this, an incompatible Node version surfaces as a cryptic
+// "ReferenceError: crypto is not defined" deep in the workflow.
+const MIN_NODE_MAJOR = 18;
+const currentVersion = process.versions.node;
+const currentMajor = parseInt(currentVersion.split(".")[0], 10);
+
+if (currentMajor < MIN_NODE_MAJOR) {
+  console.error(
+    `\nError: ecloud requires Node.js v${MIN_NODE_MAJOR} or later, but you are running v${currentVersion}.\n` +
+      `Please upgrade Node.js: https://nodejs.org/\n`,
+  );
+  process.exit(1);
+}
+
+const { execute } = await import("@oclif/core");
 
 await execute({ dir: import.meta.url });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,9 @@
   "name": "@layr-labs/ecloud-cli",
   "version": "0.0.0-development",
   "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "files": [
     "dist",
     "bin",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,6 +2,9 @@
   "name": "@layr-labs/ecloud-sdk",
   "version": "0.0.0-development",
   "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Running `ecloud app deploy` with an older node version would fail with insufficient user context:
```
ECLOUD_ENV=sepolia-dev ecloud compute app deploy --instance-type g1-standard-4t
✔ Build from verifiable source? No

Found Dockerfile in /Users/ethen/sovereign-research-agent
✔ Choose deployment method: Build and deploy from Dockerfile

📦 Build & Push Configuration
Your Docker image will be built and pushed to a registry
so that Ecloud CLI can pull and run it in the TEE.

Detected authenticated registries:
  dockerhub: ethenotethan/sovereign-research-agent:latest
  dockerhub: ethenotethan/sovereign-research-agent:latest
  dockerhub: ethenotethan/sovereign-research-agent:latest

✔ Select image destination: ethenotethan/sovereign-research-agent:latest

App name selection:
✔ Enter app name: sovereign-research-agent
Failed to fetch instance types: Environment sepolia is not available in this build type. Available environments: sepolia-dev
✔ Do you want to view your app's logs? Yes, publicly viewable by anyone
✔ Show resource usage (CPU/memory) for your app? No, disable resource usage 
monitoring
    ReferenceError: crypto is not defined
```

**Changes**
- Add preflight Node.js version validation (>=18) in CLI entry points (bin/run.js, bin/dev.js) before loading dependencies
- Declare engines field in both cli and sdk package.json files.