### PR TITLE
feat: add isolated billing mode for app deployments

### DIFF
--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -85,6 +85,13 @@ export default class AppDeploy extends Command {
       options: ["enable", "disable"],
       env: "ECLOUD_RESOURCE_USAGE_MONITORING",
     }),
+    "bill-to": Flags.string({
+      required: false,
+      description: "Billing mode: developer (default) or app (isolated billing)",
+      options: ["developer", "app"],
+      default: "developer",
+      env: "ECLOUD_BILL_TO",
+    }),
     website: Flags.string({
       required: false,
       description: "App website URL (optional)",
@@ -372,6 +379,7 @@ export default class AppDeploy extends Command {
           ? "private"
           : "off";
 
+      const billTo = flags["bill-to"] as "developer" | "app";
       const { prepared, gasEstimate } = isVerifiable
         ? await compute.app.prepareDeployFromVerifiableBuild({
             name: appName,
@@ -381,6 +389,7 @@ export default class AppDeploy extends Command {
             instanceType,
             logVisibility,
             resourceUsageMonitoring,
+            billTo,
           })
         : await compute.app.prepareDeploy({
             name: appName,
@@ -390,6 +399,7 @@ export default class AppDeploy extends Command {
             instanceType,
             logVisibility,
             resourceUsageMonitoring,
+            billTo,
           });
 
       // 9. Show gas estimate and prompt for confirmation on mainnet

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -103,6 +103,8 @@ export {
   getAppsByDeveloper,
   getActiveAppCount,
   getMaxActiveAppsPerUser,
+  getBillingType,
+  getAppsByBillingAccount,
   // Gas estimation
   estimateTransactionGas,
   formatETH,

--- a/packages/sdk/src/client/common/abis/AppController.json
+++ b/packages/sdk/src/client/common/abis/AppController.json
@@ -202,6 +202,71 @@
   },
   {
     "type": "function",
+    "name": "createAppWithIsolatedBilling",
+    "inputs": [
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "release",
+        "type": "tuple",
+        "internalType": "structIAppController.Release",
+        "components": [
+          {
+            "name": "rmsRelease",
+            "type": "tuple",
+            "internalType": "structIReleaseManagerTypes.Release",
+            "components": [
+              {
+                "name": "artifacts",
+                "type": "tuple[]",
+                "internalType": "structIReleaseManagerTypes.Artifact[]",
+                "components": [
+                  {
+                    "name": "digest",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "registry",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "upgradeByTime",
+                "type": "uint32",
+                "internalType": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "publicEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "encryptedEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "domainSeparator",
     "inputs": [],
     "outputs": [
@@ -228,6 +293,25 @@
         "name": "",
         "type": "uint32",
         "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBillingType",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
       }
     ],
     "stateMutability": "view"
@@ -312,6 +396,62 @@
     "type": "function",
     "name": "getApps",
     "inputs": [
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "apps",
+        "type": "address[]",
+        "internalType": "contractIApp[]"
+      },
+      {
+        "name": "appConfigsMem",
+        "type": "tuple[]",
+        "internalType": "structIAppController.AppConfig[]",
+        "components": [
+          {
+            "name": "creator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operatorSetId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "latestReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enumIAppController.AppStatus"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppsByBillingAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
       {
         "name": "offset",
         "type": "uint256",

--- a/packages/sdk/src/client/common/contract/caller.ts
+++ b/packages/sdk/src/client/common/contract/caller.ts
@@ -204,6 +204,7 @@ export interface PrepareDeployBatchOptions {
   release: Release;
   publicLogs: boolean;
   imageRef: string;
+  billTo?: "developer" | "app";
 }
 
 /**
@@ -253,9 +254,10 @@ export async function prepareDeployBatch(
     encryptedEnv: bytesToHex(release.encryptedEnv) as Hex,
   };
 
+  const functionName = options.billTo === "app" ? "createAppWithIsolatedBilling" : "createApp";
   const createData = encodeFunctionData({
     abi: AppControllerABI,
-    functionName: "createApp",
+    functionName,
     args: [saltHex, releaseForViem],
   });
 
@@ -1089,6 +1091,42 @@ export async function getAppsByDeveloper(
     apps: result[0],
     appConfigs: result[1],
   };
+}
+
+/**
+ * Get billing type for an app (0 = DEFAULT, 1 = ISOLATED)
+ */
+export async function getBillingType(
+  publicClient: PublicClient,
+  environmentConfig: EnvironmentConfig,
+  app: Address,
+): Promise<number> {
+  const result = await publicClient.readContract({
+    address: environmentConfig.appControllerAddress,
+    abi: AppControllerABI,
+    functionName: "getBillingType",
+    args: [app],
+  });
+  return Number(result);
+}
+
+/**
+ * Get apps by billing account (paginated)
+ */
+export async function getAppsByBillingAccount(
+  publicClient: PublicClient,
+  environmentConfig: EnvironmentConfig,
+  account: Address,
+  offset: bigint,
+  limit: bigint,
+): Promise<{ apps: Address[]; appConfigs: AppConfig[] }> {
+  const result = (await publicClient.readContract({
+    address: environmentConfig.appControllerAddress,
+    abi: AppControllerABI,
+    functionName: "getAppsByBillingAccount",
+    args: [account, offset, limit],
+  })) as [Address[], AppConfig[]];
+  return { apps: result[0], appConfigs: result[1] };
 }
 
 /**

--- a/packages/sdk/src/client/common/types/index.ts
+++ b/packages/sdk/src/client/common/types/index.ts
@@ -22,6 +22,8 @@ export interface DeployAppOpts {
   instanceType: string;
   /** Log visibility setting - required */
   logVisibility: logVisibility;
+  /** Billing mode: developer (default) or app (isolated billing) */
+  billTo?: "developer" | "app";
   /** Optional gas params from estimation */
   gas?: GasEstimate;
 }
@@ -56,6 +58,8 @@ export interface PrepareDeployOpts {
   logVisibility: logVisibility;
   /** Resource usage monitoring setting - optional */
   resourceUsageMonitoring?: "enable" | "disable";
+  /** Billing mode: developer (default) or app (isolated billing) */
+  billTo?: "developer" | "app";
 }
 
 /** Options for prepareUpgrade */
@@ -90,6 +94,8 @@ export interface PrepareDeployFromVerifiableBuildOpts {
   logVisibility: logVisibility;
   /** Resource usage monitoring setting - optional */
   resourceUsageMonitoring?: "enable" | "disable";
+  /** Billing mode: developer (default) or app (isolated billing) */
+  billTo?: "developer" | "app";
 }
 
 /** Options for prepareUpgradeFromVerifiableBuild */

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -95,6 +95,8 @@ export {
   getBlockTimestamps,
   estimateTransactionGas,
   formatETH,
+  getBillingType,
+  getAppsByBillingAccount,
   type GasEstimate,
   type EstimateGasOptions,
 } from "./common/contract/caller";

--- a/packages/sdk/src/client/modules/compute/app/deploy.ts
+++ b/packages/sdk/src/client/modules/compute/app/deploy.ts
@@ -70,6 +70,8 @@ export interface SDKDeployOptions {
   logVisibility: LogVisibility;
   /** Resource usage monitoring setting - optional, defaults to 'enable' */
   resourceUsageMonitoring?: ResourceUsageMonitoring;
+  /** Billing mode: developer (default) or app (isolated billing) */
+  billTo?: "developer" | "app";
   /** Optional gas params from estimation (use result from prepareDeploy) */
   gas?: GasEstimate;
   /** Skip telemetry (used when called from CLI) - optional */
@@ -126,6 +128,8 @@ export interface VerifiableBuildOptions {
   logVisibility: LogVisibility;
   /** Resource usage monitoring setting - optional, defaults to 'enable' */
   resourceUsageMonitoring?: ResourceUsageMonitoring;
+  /** Billing mode: developer (default) or app (isolated billing) */
+  billTo?: "developer" | "app";
   /** Skip telemetry (used when called from CLI) - optional */
   skipTelemetry?: boolean;
 }
@@ -190,9 +194,6 @@ export async function prepareDeployFromVerifiableBuild(
         logger,
       );
 
-      logger.debug("Checking quota availability...");
-      await checkQuotaAvailable(preflightCtx);
-
       // Generate salt
       const salt = generateRandomSalt();
       logger.debug(`Generated salt: ${Buffer.from(salt).toString("hex")}`);
@@ -208,6 +209,13 @@ export async function prepareDeployFromVerifiableBuild(
       logger.info(``);
       logger.info(`App ID: ${appIDToBeDeployed}`);
       logger.info(``);
+
+      // Check quota (after calculateAppID so we can use app address for isolated billing)
+      logger.debug("Checking quota availability...");
+      await checkQuotaAvailable(
+        preflightCtx,
+        options.billTo === "app" ? appIDToBeDeployed : undefined,
+      );
 
       // Build Release struct WITHOUT Docker/layering
       const release = await createReleaseFromImageDigest(
@@ -233,6 +241,7 @@ export async function prepareDeployFromVerifiableBuild(
           release,
           publicLogs,
           imageRef: options.imageRef,
+          billTo: options.billTo,
         },
         logger,
       );
@@ -370,11 +379,7 @@ export async function deploy(
         logger,
       );
 
-      // 3. Check quota availability
-      logger.debug("Checking quota availability...");
-      await checkQuotaAvailable(preflightCtx);
-
-      // 4. Check if docker is running, else try to start it
+      // 3. Check if docker is running, else try to start it
       logger.debug("Checking Docker...");
       await ensureDockerIsRunning();
 
@@ -385,11 +390,11 @@ export async function deploy(
       const envFilePath = options.envFilePath || "";
       const instanceType = options.instanceType;
 
-      // 5. Generate random salt
+      // 4. Generate random salt
       const salt = generateRandomSalt();
       logger.debug(`Generated salt: ${Buffer.from(salt).toString("hex")}`);
 
-      // 6. Get app ID (calculate from salt and address)
+      // 5. Get app ID (calculate from salt and address)
       logger.debug("Calculating app ID...");
       const appIDToBeDeployed = await calculateAppID({
         publicClient: preflightCtx.publicClient,
@@ -400,6 +405,13 @@ export async function deploy(
       logger.info(``);
       logger.info(`App ID: ${appIDToBeDeployed}`);
       logger.info(``);
+
+      // 6. Check quota availability (after calculateAppID so we can use app address for isolated billing)
+      logger.debug("Checking quota availability...");
+      await checkQuotaAvailable(
+        preflightCtx,
+        options.billTo === "app" ? appIDToBeDeployed : undefined,
+      );
 
       // 7. Prepare the release (includes build/push if needed, with automatic retry on permission errors)
       logger.info("Preparing release...");
@@ -460,8 +472,12 @@ export async function deploy(
  * Check quota availability - verifies that the user has deployment quota available
  * by checking their allowlist status on the contract
  */
-async function checkQuotaAvailable(preflightCtx: PreflightContext): Promise<void> {
-  const { publicClient, environmentConfig, selfAddress: userAddress } = preflightCtx;
+async function checkQuotaAvailable(
+  preflightCtx: PreflightContext,
+  quotaAddress?: Address,
+): Promise<void> {
+  const { publicClient, environmentConfig } = preflightCtx;
+  const userAddress = quotaAddress || preflightCtx.selfAddress;
 
   // Check user's quota limit from contract
   let maxQuota: number;
@@ -544,11 +560,7 @@ export async function prepareDeploy(
         logger,
       );
 
-      // 3. Check quota availability
-      logger.debug("Checking quota availability...");
-      await checkQuotaAvailable(preflightCtx);
-
-      // 4. Check if docker is running, else try to start it
+      // 3. Check if docker is running, else try to start it
       logger.debug("Checking Docker...");
       await ensureDockerIsRunning();
 
@@ -559,11 +571,11 @@ export async function prepareDeploy(
       const envFilePath = options.envFilePath || "";
       const instanceType = options.instanceType;
 
-      // 5. Generate random salt
+      // 4. Generate random salt
       const salt = generateRandomSalt();
       logger.debug(`Generated salt: ${Buffer.from(salt).toString("hex")}`);
 
-      // 6. Get app ID (calculate from salt and address)
+      // 5. Get app ID (calculate from salt and address)
       logger.debug("Calculating app ID...");
       const appIDToBeDeployed = await calculateAppID({
         publicClient: preflightCtx.publicClient,
@@ -574,6 +586,13 @@ export async function prepareDeploy(
       logger.info(``);
       logger.info(`App ID: ${appIDToBeDeployed}`);
       logger.info(``);
+
+      // 6. Check quota availability (after calculateAppID so we can use app address for isolated billing)
+      logger.debug("Checking quota availability...");
+      await checkQuotaAvailable(
+        preflightCtx,
+        options.billTo === "app" ? appIDToBeDeployed : undefined,
+      );
 
       // 7. Prepare the release (includes build/push if needed)
       logger.info("Preparing release...");
@@ -602,6 +621,7 @@ export async function prepareDeploy(
           release,
           publicLogs,
           imageRef: finalImageRef,
+          billTo: options.billTo,
         },
         logger,
       );

--- a/packages/sdk/src/client/modules/compute/app/index.ts
+++ b/packages/sdk/src/client/modules/compute/app/index.ts
@@ -2,7 +2,14 @@
  * Main App namespace entry point
  */
 
-import { parseAbi, encodeFunctionData, Hex, type WalletClient, type PublicClient } from "viem";
+import {
+  parseAbi,
+  encodeFunctionData,
+  Hex,
+  type Address,
+  type WalletClient,
+  type PublicClient,
+} from "viem";
 import {
   deploy as deployApp,
   prepareDeploy as prepareDeployFn,
@@ -25,7 +32,10 @@ import {
   sendAndWaitForTransaction,
   undelegate,
   isDelegated,
+  getBillingType,
+  getAppsByBillingAccount,
   type GasEstimate,
+  type AppConfig,
 } from "../../../common/contract/caller";
 import { withSDKTelemetry } from "../../../common/telemetry/wrapper";
 import { UserApiClient } from "../../../common/utils/userapi";
@@ -146,6 +156,14 @@ export interface AppModule {
   stop: (appId: AppId, opts?: LifecycleOpts) => Promise<{ tx: Hex | false }>;
   terminate: (appId: AppId, opts?: LifecycleOpts) => Promise<{ tx: Hex | false }>;
 
+  // Billing
+  getBillingType: (appId: AppId) => Promise<number>;
+  getAppsByBillingAccount: (
+    account: Address,
+    offset: bigint,
+    limit: bigint,
+  ) => Promise<{ apps: Address[]; appConfigs: AppConfig[] }>;
+
   // Delegation
   isDelegated: () => Promise<boolean>;
   undelegate: () => Promise<{ tx: Hex | false }>;
@@ -247,6 +265,7 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
           imageRef: opts.imageRef,
           logVisibility: opts.logVisibility,
           resourceUsageMonitoring: opts.resourceUsageMonitoring,
+          billTo: opts.billTo,
           skipTelemetry,
         },
         logger,
@@ -266,6 +285,7 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
           imageDigest: opts.imageDigest,
           logVisibility: opts.logVisibility,
           resourceUsageMonitoring: opts.resourceUsageMonitoring,
+          billTo: opts.billTo,
           skipTelemetry,
         },
         logger,
@@ -506,6 +526,14 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
           return { tx };
         },
       );
+    },
+
+    async getBillingType(appId) {
+      return getBillingType(publicClient, environment, appId);
+    },
+
+    async getAppsByBillingAccount(account, offset, limit) {
+      return getAppsByBillingAccount(publicClient, environment, account, offset, limit);
     },
 
     async isDelegated() {


### PR DESCRIPTION
## Add isolated billing support (`billTo: "app"`)

Adds SDK + CLI support for isolated billing, where an app is billed to its own address instead of the developer's. Maps to the new `createAppWithIsolatedBilling` contract function from [eigenx-contracts#17](https://github.com/Layr-Labs/eigenx-contracts/pull/17).

### Changes

- **ABI**: Add `createAppWithIsolatedBilling`, `getBillingType`, `getAppsByBillingAccount`
- **SDK types**: Add `billTo?: "developer" | "app"` to deploy option interfaces
- **Contract caller**: Conditional function name encoding in `prepareDeployBatch()`; new `getBillingType()` and `getAppsByBillingAccount()` read functions
- **Deploy module**: Reorder quota check after `calculateAppID()` so isolated billing can check quota against the app address; thread `billTo` through all three deploy paths
- **App module**: Expose `getBillingType` and `getAppsByBillingAccount` on `AppModule`
- **CLI**: Add `--bill-to` flag (`developer` | `app`, default `developer`)
- **Exports**: Add new functions to `client/index.ts` and `browser.ts`

### Usage

```bash
ecloud compute app deploy --bill-to app
```

```typescript
await compute.app.prepareDeploy({ ..., billTo: "app" });
```

Default behavior (`billTo: "developer"`) is unchanged.