### PR TITLE
feat(cli): add shell autocomplete support for bash and zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,34 @@ ACME_FORCE_ISSUE=true  # Only if staging cert exists
 - Test with staging certificates first to avoid rate limits
 - DNS changes may take a few minutes to propagate
 
+## Shell Autocomplete
+
+Enable tab-completion for commands and flags in your shell:
+
+### Bash
+
+```bash
+ecloud autocomplete bash
+```
+
+Follow the printed instructions to add the completion script to your `~/.bashrc` (or `~/.bash_profile`).
+
+### Zsh
+
+```bash
+ecloud autocomplete zsh
+```
+
+Follow the printed instructions to add the completion script to your `~/.zshrc`.
+
+### After CLI Upgrades
+
+Refresh the completion cache so new commands and flags are available:
+
+```bash
+ecloud autocomplete --refresh-cache
+```
+
 ## Advanced Usage
 
 ### Building and Pushing Images Manually

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,8 @@
     "js-yaml": "^4.1.1",
     "node-forge": "^1.3.2",
     "open": "^11.0.0",
-    "viem": "^2.38.6"
+    "viem": "^2.38.6",
+    "@oclif/plugin-autocomplete": "^3.2.43"
   },
   "scripts": {
     "build": "tsup",
@@ -41,6 +42,9 @@
   },
   "oclif": {
     "bin": "ecloud",
+    "plugins": [
+      "@oclif/plugin-autocomplete"
+    ],
     "commands": "./dist/commands",
     "dirname": "",
     "topicSeparator": " ",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@oclif/core':
         specifier: ^4.8.0
         version: 4.8.0
+      '@oclif/plugin-autocomplete':
+        specifier: ^3.2.43
+        version: 3.2.43
       axios:
         specifier: ^1.13.2
         version: 1.13.2
@@ -662,6 +665,10 @@ packages:
 
   '@oclif/core@4.8.0':
     resolution: {integrity: sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==}
+    engines: {node: '>=18.0.0'}
+
+  '@oclif/plugin-autocomplete@3.2.43':
+    resolution: {integrity: sha512-Gz+z85f6PbnG9aphBe2IDD/IhYWRN9aOPIpiKG1bhJV3lKLiFHo26ZEWmB9+7Or+JCqcMMoi/4hEX/HaidMpSg==}
     engines: {node: '>=18.0.0'}
 
   '@pkgr/core@0.2.9':
@@ -2750,6 +2757,15 @@ snapshots:
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
+
+  '@oclif/plugin-autocomplete@3.2.43':
+    dependencies:
+      '@oclif/core': 4.8.0
+      ansis: 3.17.0
+      debug: 4.4.3(supports-color@8.1.1)
+      ejs: 3.1.10
+    transitivePeerDependencies:
+      - supports-color
 
   '@pkgr/core@0.2.9': {}
 


### PR DESCRIPTION
## Summary

- Adds `@oclif/plugin-autocomplete` to enable tab-completion for all ecloud CLI commands and flags
- Registers the plugin in the oclif config so `ecloud autocomplete [bash|zsh]` is available out of the box
- Updates the README with setup instructions for bash and zsh

## Details

The ecloud CLI now supports shell auto-completion via the official oclif autocomplete plugin. Users run `ecloud autocomplete bash` or `ecloud autocomplete zsh` to get setup instructions, then enjoy tab-completion for:

- All top-level commands (`auth`, `billing`, `compute`, `telemetry`, `upgrade`, `version`)
- All nested subcommands (`compute app deploy`, `compute build submit`, etc.)
- All flag names (`--dockerfile`, `--env-file`, `--image-ref`, etc.)

Completions are generated at runtime by introspecting the CLI's command tree, so they stay in sync automatically. After upgrading the CLI, users can run `ecloud autocomplete --refresh-cache` to pick up new commands.

## Changes

- `packages/cli/package.json` — added `@oclif/plugin-autocomplete` dependency and registered it in the oclif `plugins` array
- `pnpm-lock.yaml` — updated lockfile
- `README.md` — added "Shell Autocomplete" section with bash/zsh setup instructions
- `docs/shell-autocomplete-plan.md` — implementation plan (all steps complete)

## Test plan

- [x] `pnpm build` succeeds with no new errors
- [x] `ecloud autocomplete --help` shows the command
- [x] `ecloud autocomplete bash` prints valid setup instructions
- [x] `ecloud autocomplete zsh` prints valid setup instructions
- [x] `ecloud autocomplete --refresh-cache` regenerates the cache
- [x] Bash completion simulation confirms all commands, subcommands, and flags resolve correctly
- [x] `pnpm lint` passes with no new warnings
- [x] Typecheck errors are pre-existing on master (viem/abitype unrelated)
