### PR TITLE
fix(security): patch critical axios SSRF vuln (GHSA-3p68-rc4w-qgx5)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     "@napi-rs/keyring": "1.2.0",
     "@oclif/core": "4.8.0",
     "@oclif/plugin-autocomplete": "3.2.40",
-    "axios": "1.14.0",
+    "axios": "1.15.0",
     "chalk": "5.6.2",
     "cli-table3": "0.6.5",
     "dockerode": "4.0.9",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@inquirer/prompts": "7.10.1",
     "@napi-rs/keyring": "1.2.0",
-    "axios": "1.14.0",
+    "axios": "1.15.0",
     "chalk": "5.6.2",
     "dockerode": "4.0.9",
     "form-data": "4.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: 3.2.40
         version: 3.2.40
       axios:
-        specifier: 1.14.0
-        version: 1.14.0
+        specifier: 1.15.0
+        version: 1.15.0
       chalk:
         specifier: 5.6.2
         version: 5.6.2
@@ -124,8 +124,8 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       axios:
-        specifier: 1.14.0
-        version: 1.14.0
+        specifier: 1.15.0
+        version: 1.15.0
       chalk:
         specifier: 5.6.2
         version: 5.6.2
@@ -1082,8 +1082,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -3144,7 +3144,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5


### PR DESCRIPTION
## Summary

- Upgrade `axios` from `1.14.0` to `1.15.0` in `packages/cli` and `packages/sdk`
- Fixes **CRITICAL** GHSA-3p68-rc4w-qgx5: NO_PROXY hostname normalization bypass leading to SSRF
- No breaking semver change (minor version bump within 1.x)

## Test plan

- [ ] `pnpm audit --audit-level critical` returns 0 critical vulnerabilities
- [ ] `pnpm install` completes without errors
- [ ] Existing CLI and SDK functionality unaffected (axios 1.14→1.15 is non-breaking)

## Remaining non-critical issues (no action taken per task scope)

| Severity | Package | CVE | Note |
|----------|---------|-----|------|
| high | vite | GHSA-v2wj-q39q-566r | Dev-only via vitest; `server.fs.deny` bypass |
| high | vite | GHSA-p9ff-h696-f583 | Dev-only via vitest; WebSocket arbitrary file read |
| moderate | vite | GHSA-4w7w-66w2-5vf9 | Dev-only via vitest; path traversal in `.map` handling |

All three vite issues are in `vitest` (devDependency at root). Fixing them requires bumping `vitest@4.0.16` — outside the scope of this critical-only patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)