### PR TITLE
fix(security): SHA-pin GitHub Actions in workflows

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -41,12 +41,12 @@ jobs:
           echo "Building dev version: $PACKAGE_VERSION"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -89,12 +89,12 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- Pin `pnpm/action-setup` to commit SHA `b906affcce14559ad1aafd4ab0e942779e9f58b1` (v4.3.0) in both release-dev and release-prod workflows
- Pin `actions/setup-node` to commit SHA `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0) in both release-dev and release-prod workflows
- `actions/checkout` was already SHA-pinned at `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)

Pinning to commit SHAs prevents supply chain attacks via mutable tag references. No version upgrades — each action is pinned to the exact commit its current version tag points to.

## Verification
| Action | Version | SHA | Verified |
|--------|---------|-----|----------|
| `actions/checkout` | v4.2.2 | `11bd719` | Already pinned |
| `pnpm/action-setup` | v4.3.0 | `b906aff` | Via GitHub API |
| `actions/setup-node` | v4.4.0 | `4993ea5` | Via GitHub API |

## Test plan
- [ ] Verify dev release workflow triggers correctly on dev tag push
- [ ] Verify prod release workflow triggers correctly on prod tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)