### PR TITLE
feat(attest): add extraData parameter for runtime attestation

### DIFF
--- a/packages/sdk/src/client/modules/attest/attest-client.test.ts
+++ b/packages/sdk/src/client/modules/attest/attest-client.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AttestClient } from './attest-client';
+import http from 'node:http';
+import { EventEmitter } from 'node:events';
+
+function makeMockHttp(responseData: Buffer, statusCode = 200) {
+  const mockRes = new EventEmitter() as any;
+  mockRes.statusCode = statusCode;
+  const mockReq = new EventEmitter() as any;
+  const capturedBodies: string[] = [];
+  mockReq.write = (body: string) => { capturedBodies.push(body); };
+  mockReq.end = () => {
+    setTimeout(() => {
+      mockRes.emit('data', responseData);
+      mockRes.emit('end');
+    }, 0);
+  };
+  return { mockRes, mockReq, capturedBodies };
+}
+
+describe('AttestClient extraData', () => {
+  it('passes extra_data to TEE server when extraData is provided', async () => {
+    const { mockRes, mockReq, capturedBodies } = makeMockHttp(Buffer.from('fake-attestation-bytes'));
+    vi.spyOn(http, 'request').mockImplementation((_opts: any, cb: any) => { cb(mockRes); return mockReq; });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { encryptedToken: 'fake-jwe' }, signature: Buffer.from('fake-sig').toString('base64') }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new AttestClient({ kmsServerURL: 'http://localhost:8080', kmsPublicKey: 'fake-key', audience: 'test' });
+    const extraData = Buffer.alloc(32, 0xab);
+
+    try { await client.attest(extraData); } catch { /* signature will fail */ }
+
+    expect(capturedBodies.length).toBeGreaterThan(0);
+    const teeBody = JSON.parse(capturedBodies[0]);
+    expect(teeBody.extra_data).toBe(extraData.toString('base64'));
+
+    vi.restoreAllMocks();
+  });
+
+  it('omits extra_data when extraData is not provided', async () => {
+    const { mockRes, mockReq, capturedBodies } = makeMockHttp(Buffer.from('fake-attestation-bytes'));
+    vi.spyOn(http, 'request').mockImplementation((_opts: any, cb: any) => { cb(mockRes); return mockReq; });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { encryptedToken: 'fake-jwe' }, signature: Buffer.from('fake-sig').toString('base64') }),
+    }));
+
+    const client = new AttestClient({ kmsServerURL: 'http://localhost:8080', kmsPublicKey: 'fake-key', audience: 'test' });
+    try { await client.attest(); } catch { /* expected */ }
+
+    const teeBody = JSON.parse(capturedBodies[0]);
+    expect(teeBody.extra_data).toBeUndefined();
+
+    vi.restoreAllMocks();
+  });
+
+  it('passes extra_data to KMS when extraData is provided', async () => {
+    const { mockRes, mockReq } = makeMockHttp(Buffer.from('fake-attestation-bytes'));
+    vi.spyOn(http, 'request').mockImplementation((_opts: any, cb: any) => { cb(mockRes); return mockReq; });
+
+    const kmsCapture: string[] = [];
+    const mockFetch = vi.fn().mockImplementation(async (_url: string, opts: any) => {
+      kmsCapture.push(opts.body);
+      return { ok: true, json: async () => ({ data: { encryptedToken: 'fake-jwe' }, signature: Buffer.from('fake-sig').toString('base64') }) };
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new AttestClient({ kmsServerURL: 'http://localhost:8080', kmsPublicKey: 'fake-key', audience: 'test' });
+    const extraData = Buffer.alloc(32, 0xcd);
+    try { await client.attest(extraData); } catch { /* expected */ }
+
+    expect(kmsCapture.length).toBeGreaterThan(0);
+    const kmsBody = JSON.parse(kmsCapture[0]);
+    expect(kmsBody.extra_data).toBe(extraData.toString('base64'));
+
+    vi.restoreAllMocks();
+  });
+
+  it('throws if extraData exceeds 64 bytes', async () => {
+    const client = new AttestClient({ kmsServerURL: 'http://localhost:8080', kmsPublicKey: 'fake-key', audience: 'test' });
+    const tooLarge = Buffer.alloc(65);
+    await expect(client.attest(tooLarge)).rejects.toThrow('extraData exceeds 64-byte hardware limit');
+  });
+});

--- a/packages/sdk/src/client/modules/attest/attest-client.test.ts
+++ b/packages/sdk/src/client/modules/attest/attest-client.test.ts
@@ -35,7 +35,7 @@ describe('AttestClient extraData', () => {
 
     expect(capturedBodies.length).toBeGreaterThan(0);
     const teeBody = JSON.parse(capturedBodies[0]);
-    expect(teeBody.extra_data).toBe(extraData.toString('base64'));
+    expect(teeBody.extra_data).toBe(extraData.toString('hex'));
 
     vi.restoreAllMocks();
   });
@@ -74,7 +74,7 @@ describe('AttestClient extraData', () => {
 
     expect(kmsCapture.length).toBeGreaterThan(0);
     const kmsBody = JSON.parse(kmsCapture[0]);
-    expect(kmsBody.extra_data).toBe(extraData.toString('base64'));
+    expect(kmsBody.extra_data).toBe(extraData.toString('hex'));
 
     vi.restoreAllMocks();
   });

--- a/packages/sdk/src/client/modules/attest/attest-client.test.ts
+++ b/packages/sdk/src/client/modules/attest/attest-client.test.ts
@@ -35,7 +35,7 @@ describe('AttestClient extraData', () => {
 
     expect(capturedBodies.length).toBeGreaterThan(0);
     const teeBody = JSON.parse(capturedBodies[0]);
-    expect(teeBody.extra_data).toBe(extraData.toString('hex'));
+    expect(teeBody.extra_data).toBe(extraData.toString('base64'));
 
     vi.restoreAllMocks();
   });
@@ -74,14 +74,14 @@ describe('AttestClient extraData', () => {
 
     expect(kmsCapture.length).toBeGreaterThan(0);
     const kmsBody = JSON.parse(kmsCapture[0]);
-    expect(kmsBody.extra_data).toBe(extraData.toString('hex'));
+    expect(kmsBody.extra_data).toBe(extraData.toString('base64'));
 
     vi.restoreAllMocks();
   });
 
-  it('throws if extraData exceeds 64 bytes', async () => {
+  it('throws if extraData exceeds 1MB', async () => {
     const client = new AttestClient({ kmsServerURL: 'http://localhost:8080', kmsPublicKey: 'fake-key', audience: 'test' });
-    const tooLarge = Buffer.alloc(65);
-    await expect(client.attest(tooLarge)).rejects.toThrow('extraData exceeds 64-byte hardware limit');
+    const tooLarge = Buffer.alloc(1_048_576 + 1);
+    await expect(client.attest(tooLarge)).rejects.toThrow('extraData exceeds 1MB limit');
   });
 });

--- a/packages/sdk/src/client/modules/attest/attest-client.ts
+++ b/packages/sdk/src/client/modules/attest/attest-client.ts
@@ -22,10 +22,10 @@ export class AttestClient {
   }
 
   async attest(extraData?: Buffer): Promise<string> {
-    // Intel TDX REPORTDATA and AMD SEV-SNP ReportData fields are exactly 64 bytes
-    // at the hardware level. Callers must pre-hash large payloads (SHA-512 = 64 bytes).
-    if (extraData && extraData.length > 64) {
-      throw new Error(`extraData exceeds 64-byte hardware limit (${extraData.length} bytes); pre-hash with SHA-512 before passing`);
+    // go-tpm-tools hashes extraData (SHA-256/SHA-512) before binding it into the
+    // hardware nonce, so callers can pass arbitrary data up to 1MB.
+    if (extraData && extraData.length > 1_048_576) {
+      throw new Error(`extraData exceeds 1MB limit (${extraData.length} bytes)`);
     }
 
     const { publicKey, privateKey } = generateKeyPairSync('rsa', {
@@ -89,7 +89,7 @@ export class AttestClient {
     return new Promise((resolve, reject) => {
       const requestBody: Record<string, string> = { challenge: challenge.toString('base64') };
       if (extraData && extraData.length > 0) {
-        requestBody.extra_data = extraData.toString('hex');
+        requestBody.extra_data = extraData.toString('base64');
       }
       const body = JSON.stringify(requestBody);
 
@@ -135,7 +135,7 @@ export class AttestClient {
       audience: this.config.audience,
     };
     if (extraData && extraData.length > 0) {
-      requestBody.extra_data = extraData.toString('hex');
+      requestBody.extra_data = extraData.toString('base64');
     }
     const body = JSON.stringify(requestBody);
 

--- a/packages/sdk/src/client/modules/attest/attest-client.ts
+++ b/packages/sdk/src/client/modules/attest/attest-client.ts
@@ -89,7 +89,7 @@ export class AttestClient {
     return new Promise((resolve, reject) => {
       const requestBody: Record<string, string> = { challenge: challenge.toString('base64') };
       if (extraData && extraData.length > 0) {
-        requestBody.extra_data = extraData.toString('base64');
+        requestBody.extra_data = extraData.toString('hex');
       }
       const body = JSON.stringify(requestBody);
 
@@ -135,7 +135,7 @@ export class AttestClient {
       audience: this.config.audience,
     };
     if (extraData && extraData.length > 0) {
-      requestBody.extra_data = extraData.toString('base64');
+      requestBody.extra_data = extraData.toString('hex');
     }
     const body = JSON.stringify(requestBody);
 

--- a/packages/sdk/src/client/modules/attest/attest-client.ts
+++ b/packages/sdk/src/client/modules/attest/attest-client.ts
@@ -21,7 +21,13 @@ export class AttestClient {
     this.config = config;
   }
 
-  async attest(): Promise<string> {
+  async attest(extraData?: Buffer): Promise<string> {
+    // Intel TDX REPORTDATA and AMD SEV-SNP ReportData fields are exactly 64 bytes
+    // at the hardware level. Callers must pre-hash large payloads (SHA-512 = 64 bytes).
+    if (extraData && extraData.length > 64) {
+      throw new Error(`extraData exceeds 64-byte hardware limit (${extraData.length} bytes); pre-hash with SHA-512 before passing`);
+    }
+
     const { publicKey, privateKey } = generateKeyPairSync('rsa', {
       modulusLength: 4096,
       publicKeyEncoding: { type: 'spki', format: 'pem' } as const,
@@ -35,8 +41,8 @@ export class AttestClient {
       .digest();
 
     const socketPath = this.config.socketPath ?? DEFAULT_SOCKET_PATH;
-    const attestationBytes = await this.getAttestation(socketPath, challengeHash);
-    const attestResponse = await this.postAttest(attestationBytes, publicKey);
+    const attestationBytes = await this.getAttestation(socketPath, challengeHash, extraData);
+    const attestResponse = await this.postAttest(attestationBytes, publicKey, extraData);
 
     this.verifySignature(JSON.stringify(attestResponse.data), attestResponse.signature);
 
@@ -79,9 +85,13 @@ export class AttestClient {
     }
   }
 
-  private getAttestation(socketPath: string, challenge: Buffer): Promise<Buffer> {
+  private getAttestation(socketPath: string, challenge: Buffer, extraData?: Buffer): Promise<Buffer> {
     return new Promise((resolve, reject) => {
-      const body = JSON.stringify({ challenge: challenge.toString('base64') });
+      const requestBody: Record<string, string> = { challenge: challenge.toString('base64') };
+      if (extraData && extraData.length > 0) {
+        requestBody.extra_data = extraData.toString('base64');
+      }
+      const body = JSON.stringify(requestBody);
 
       const req = http.request(
         {
@@ -115,14 +125,19 @@ export class AttestClient {
   private async postAttest(
     attestationBytes: Buffer,
     rsaPublicKey: string,
+    extraData?: Buffer,
   ): Promise<{ data: { encryptedToken: string }; signature: string }> {
     const url = `${this.config.kmsServerURL}/auth/attest`;
-    const body = JSON.stringify({
+    const requestBody: Record<string, unknown> = {
       version: 3,
       attestation: attestationBytes.toString('base64'),
       rsaKey: rsaPublicKey,
       audience: this.config.audience,
-    });
+    };
+    if (extraData && extraData.length > 0) {
+      requestBody.extra_data = extraData.toString('base64');
+    }
+    const body = JSON.stringify(requestBody);
 
     const response = await fetch(url, {
       method: 'POST',

--- a/packages/sdk/src/client/modules/attest/jwt-provider.test.ts
+++ b/packages/sdk/src/client/modules/attest/jwt-provider.test.ts
@@ -90,6 +90,50 @@ describe('JwtProvider', () => {
     expect(client.attest).toHaveBeenCalledTimes(2);
   });
 
+  it('skips cache and fetches fresh token when extraData is provided', async () => {
+    const token1 = makeJwt(futureExp);
+    const token2 = makeJwt(futureExp + 1);
+    let callCount = 0;
+    const client = mockAttestClient(async () => callCount++ === 0 ? token1 : token2);
+    const provider = new JwtProvider(client);
+
+    const first = await provider.getToken();
+    expect(first).toBe(token1);
+
+    const extraData = Buffer.from('some-action-hash');
+    const second = await provider.getToken(extraData);
+    expect(second).toBe(token2);
+    expect(client.attest).toHaveBeenCalledTimes(2);
+    expect(client.attest).toHaveBeenLastCalledWith(extraData);
+  });
+
+  it('deduplicates concurrent extraData requests with same key', async () => {
+    let resolveAttest: (token: string) => void;
+    const client = mockAttestClient(
+      () => new Promise<string>((resolve) => { resolveAttest = resolve; }),
+    );
+    const provider = new JwtProvider(client);
+    const extraData = Buffer.from('same-action');
+
+    const p1 = provider.getToken(extraData);
+    const p2 = provider.getToken(extraData);
+    const token = makeJwt(futureExp);
+    resolveAttest!(token);
+
+    const results = await Promise.all([p1, p2]);
+    expect(results).toEqual([token, token]);
+    expect(client.attest).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not deduplicate extraData requests with different keys', async () => {
+    const client = mockAttestClient(async () => makeJwt(futureExp));
+    const provider = new JwtProvider(client);
+
+    await provider.getToken(Buffer.from('action-a'));
+    await provider.getToken(Buffer.from('action-b'));
+    expect(client.attest).toHaveBeenCalledTimes(2);
+  });
+
   it('clears pending promise on error so concurrent waiters also fail', async () => {
     let rejectAttest: (err: Error) => void;
     const client = mockAttestClient(

--- a/packages/sdk/src/client/modules/attest/jwt-provider.ts
+++ b/packages/sdk/src/client/modules/attest/jwt-provider.ts
@@ -6,13 +6,28 @@ export class JwtProvider {
   private cachedToken?: string;
   private expiresAt?: number;
   private pending?: Promise<string>;
+  private pendingExtraData = new Map<string, Promise<string>>();
 
   constructor(attestClient: AttestClient, bufferSeconds: number = 30) {
     this.attestClient = attestClient;
     this.bufferSeconds = bufferSeconds;
   }
 
-  async getToken(): Promise<string> {
+  async getToken(extraData?: Buffer): Promise<string> {
+    // When extraData is provided, bypass long-lived cache but deduplicate
+    // concurrent requests for the same extraData to avoid thundering herd
+    // on TEE hardware calls.
+    if (extraData && extraData.length > 0) {
+      const key = extraData.toString('hex');
+      const existing = this.pendingExtraData.get(key);
+      if (existing) return existing;
+      const promise = this.attestClient.attest(extraData).finally(() => {
+        this.pendingExtraData.delete(key);
+      });
+      this.pendingExtraData.set(key, promise);
+      return promise;
+    }
+
     if (this.cachedToken && !this.isExpiringSoon()) {
       return this.cachedToken;
     }


### PR DESCRIPTION
## Summary

Adds optional `extraData` parameter to `AttestClient.attest()` and `JwtProvider.getToken()` for binding arbitrary application data (e.g., hash of a blog post, agent configuration) into TEE attestation evidence.

When `extraData` is provided, the SDK sends it as `extra_data` (base64) to the TEE server's `/v1/bound_evidence` endpoint and to the KMS `/auth/attest` endpoint. go-tpm-tools cryptographically binds `extra_data` into the attestation nonce via SHA-256/SHA-512 hashing, so arbitrary data up to 1MB is supported. When omitted, behavior is unchanged — fully backwards compatible.

`JwtProvider.getToken(extraData)` bypasses the long-lived token cache (each runtime attestation is per-action) but deduplicates concurrent requests for the same `extraData` via an in-flight promise map, preventing thundering herd on TEE hardware calls.

Companion PR: Layr-Labs/eigenx-kms#17 — KMS server-side changes to accept `extra_data`, verify it in the nonce, and embed it in the issued JWT.

## Changes

- `attest-client.ts` — `attest(extraData?: Buffer)` with 1MB size limit
- `jwt-provider.ts` — `getToken(extraData?: Buffer)` with per-key dedup map
- New `attest-client.test.ts` — 4 tests (TEE forwarding, KMS forwarding, omission, size limit)
- Updated `jwt-provider.test.ts` — 3 new tests (cache bypass, dedup, different keys)

## Test plan

- [x] `npx vitest run packages/sdk/src/client/modules/attest/` — 13 tests passing
- [x] E2E on AMD SEV-SNP (GCP Confidential Space, `n2d`) — JWT contains `extra_data` claim
- [x] E2E on Intel TDX (GCP Confidential Space, `c3`) — JWT contains `extra_data` claim
- [x] E2E on GCP Shielded VM / vTPM (`e2`) — JWT contains `extra_data` claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)