### PR TITLE
fix(cli): restore non-interactive behavior for explicit --environment and --force

### DIFF
--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -261,7 +261,7 @@ export default class AppDeploy extends Command {
         // Interactive verifiable selection when --verifiable is not set.
         // If the user explicitly provided --dockerfile, assume they want the normal local-build flow.
         if (!flags.dockerfile) {
-          const useVerifiable = await promptUseVerifiableBuild();
+          const useVerifiable = await promptUseVerifiableBuild(flags.force);
           if (useVerifiable) {
             const sourceType = await promptVerifiableSourceType();
             verifiableMode = sourceType;

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -197,7 +197,7 @@ export default class AppUpgrade extends Command {
         // Interactive verifiable selection when --verifiable is not set.
         // If the user explicitly provided --dockerfile, assume they want the normal local-build flow.
         if (!flags.dockerfile) {
-          const useVerifiable = await promptUseVerifiableBuild();
+          const useVerifiable = await promptUseVerifiableBuild(flags.force);
           if (useVerifiable) {
             const sourceType = await promptVerifiableSourceType();
             verifiableMode = sourceType;

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getEnvironmentInteractive, promptUseVerifiableBuild } from "../prompts";
+
+/**
+ * Regression tests for two non-interactive mode bugs introduced in PR #126:
+ *
+ *   1. `getEnvironmentInteractive("mainnet-alpha")` in a dev build silently
+ *      swallowed the real error ("not available in this build type") and
+ *      surfaced the generic "Cannot prompt in non-interactive mode" message.
+ *   2. `promptUseVerifiableBuild()` had no knowledge of `--force`, so any
+ *      image-ref-only `app deploy` / `app upgrade` in non-TTY mode threw
+ *      `Cannot confirm "Build from verifiable source?" in non-interactive mode.
+ *      Use --force to skip confirmation prompts.` even when --force was set.
+ */
+describe("prompts non-interactive regressions", () => {
+  const origBuildType = process.env.BUILD_TYPE;
+  const origIsTTY = process.stdin.isTTY;
+
+  afterEach(() => {
+    if (origBuildType === undefined) delete process.env.BUILD_TYPE;
+    else process.env.BUILD_TYPE = origBuildType;
+    process.stdin.isTTY = origIsTTY;
+    vi.restoreAllMocks();
+  });
+
+  describe("getEnvironmentInteractive", () => {
+    it("returns the environment verbatim when it is valid and available", async () => {
+      process.env.BUILD_TYPE = "prod";
+      await expect(getEnvironmentInteractive("sepolia")).resolves.toBe("sepolia");
+      await expect(getEnvironmentInteractive("mainnet-alpha")).resolves.toBe("mainnet-alpha");
+    });
+
+    it("surfaces 'Unknown environment' for an unrecognized value", async () => {
+      process.env.BUILD_TYPE = "prod";
+      await expect(getEnvironmentInteractive("bogusenv")).rejects.toThrow(
+        /Unknown environment: bogusenv/,
+      );
+    });
+
+    it("surfaces 'not available in this build type' for envs missing from the current build", async () => {
+      // Bug 1 scenario: user installed a dev build, then ran a command with
+      // --environment mainnet-alpha. Previously they got the misleading
+      // "Cannot prompt in non-interactive mode" error. Now they get the
+      // real reason, referencing the build type.
+      //
+      // The SDK bakes BUILD_TYPE in at build time via tsup define, so
+      // `process.env.BUILD_TYPE` at runtime cannot flip it back to "dev".
+      // Instead, exercise the inverse: in the prod-built SDK used by tests,
+      // "sepolia-dev" is the environment that is *not* available — same
+      // code path, same error shape.
+      process.env.BUILD_TYPE = "prod";
+      await expect(getEnvironmentInteractive("sepolia-dev")).rejects.toThrow(
+        /not available in this build type/,
+      );
+    });
+
+    it("falls through to the interactive guard only when no environment is supplied", async () => {
+      process.env.BUILD_TYPE = "prod";
+      process.stdin.isTTY = false;
+      await expect(getEnvironmentInteractive(undefined)).rejects.toThrow(
+        /Cannot prompt in non-interactive mode/,
+      );
+    });
+  });
+
+  describe("promptUseVerifiableBuild", () => {
+    it("short-circuits to false when force is true, even in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      await expect(promptUseVerifiableBuild(true)).resolves.toBe(false);
+    });
+
+    it("throws the 'Use --force' guidance when force is false in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      await expect(promptUseVerifiableBuild(false)).rejects.toThrow(
+        /Cannot confirm "Build from verifiable source\?" in non-interactive mode\. Use --force/,
+      );
+    });
+
+    it("defaults force to false so existing callers still see the non-interactive error", async () => {
+      process.stdin.isTTY = false;
+      await expect(promptUseVerifiableBuild()).rejects.toThrow(
+        /Cannot confirm "Build from verifiable source\?" in non-interactive mode/,
+      );
+    });
+  });
+});

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -15,7 +15,6 @@ import { privateKeyToAccount } from "viem/accounts";
 import {
   getEnvironmentConfig,
   getAvailableEnvironments,
-  isEnvironmentAvailable,
   getAllAppsByDeveloper,
   getCategoryDescriptions,
   fetchTemplateCatalog,
@@ -152,8 +151,14 @@ function detectGitRepoInfo(): { repoUrl?: string; commitSha?: string } {
 
 /**
  * Prompt: "Build from verifiable source?" (only used when --verifiable is not set)
+ *
+ * When `force` is true (i.e. the user passed --force), skip the prompt entirely
+ * and return the default answer (false = regular build). Without this short-circuit,
+ * `confirmWithDefault` throws in non-interactive mode, which means --force on an
+ * image-ref-only deploy or upgrade was unusable in CI.
  */
-export async function promptUseVerifiableBuild(): Promise<boolean> {
+export async function promptUseVerifiableBuild(force: boolean = false): Promise<boolean> {
+  if (force) return false;
   return confirmWithDefault("Build from verifiable source?", false);
 }
 
@@ -1522,15 +1527,15 @@ export async function getPrivateKeyInteractive(privateKey?: string): Promise<str
  */
 export async function getEnvironmentInteractive(environment?: string): Promise<string> {
   if (environment) {
-    try {
-      getEnvironmentConfig(environment);
-      if (!isEnvironmentAvailable(environment)) {
-        throw new Error(`Environment ${environment} is not available in this build`);
-      }
-      return environment;
-    } catch {
-      // Invalid environment, continue to prompt
-    }
+    // Validate the explicit value and surface the real error to the user.
+    // getEnvironmentConfig throws a descriptive error for unknown environments
+    // AND for environments not available in the current build (dev vs prod).
+    // Previously we caught this silently and fell through to the interactive
+    // prompt, which in non-TTY mode surfaced the generic "Cannot prompt in
+    // non-interactive mode" error — hiding the real reason (e.g. "mainnet-alpha
+    // is not available in this build type" when using a dev build).
+    getEnvironmentConfig(environment);
+    return environment;
   }
 
   ensureInteractive("--environment or ECLOUD_ENV");


### PR DESCRIPTION
## Summary

Two regressions from #126 surface as opaque "Cannot prompt in non-interactive mode" errors in CI and scripted flows. Both are fixed here in one PR.

### Bug 1 ``--environment`` / ``ECLOUD_ENV`` swallowed the real error

``getEnvironmentInteractive`` wrapped environment validation in a silent ``try/catch``, so any error from ``getEnvironmentConfig`` (unknown env, env unavailable in current build type) fell through to ``ensureInteractive`` and surfaced as a generic "Cannot prompt in non-interactive mode. Provide ``--environment`` or ``ECLOUD_ENV`` via CLI flags or environment variables" — even when the user had provided those exact values.

The real errors (``Unknown environment: X``, ``Environment X is not available in this build type. Available environments: Y``) are now surfaced directly, and the interactive guard only fires when nothing was provided at all.

**Before (prod CLI with an env that is valid but unavailable, e.g. ``sepolia-dev``):**

```
$ ECLOUD_ENV=sepolia-dev ecloud compute app info 0x...
Error: Cannot prompt in non-interactive mode. Provide --environment
or ECLOUD_ENV via CLI flags or environment variables.
```

**After:**

```
$ ECLOUD_ENV=sepolia-dev ecloud compute app info 0x...
Error: Environment sepolia-dev is not available in this build type.
Available environments: sepolia, mainnet-alpha
```

**Before (unknown env):**

```
$ ECLOUD_ENV=bogusenv ecloud compute app info 0x...
Error: Cannot prompt in non-interactive mode...
```

**After:**

```
$ ECLOUD_ENV=bogusenv ecloud compute app info 0x...
Error: Unknown environment: bogusenv
```

### Bug 2 ``--force`` did not skip the "Build from verifiable source?" prompt

``promptUseVerifiableBuild`` was called unconditionally from ``app deploy`` and ``app upgrade`` in the image-ref-only path (no ``--dockerfile``). It routes through ``confirmWithDefault``, which throws in non-TTY with the message "Use --force to skip confirmation prompts." — but the function had no ``--force`` awareness, so passing ``--force`` did nothing.

Now ``promptUseVerifiableBuild(force)`` short-circuits to the default answer (``false`` = non-verifiable) when ``force`` is true, matching the existing pattern in ``auth/login.ts``.

**Before:**

```
$ ecloud compute app deploy --image-ref X:Y --env-file .env ... --force
Error: Cannot confirm "Build from verifiable source?" in non-interactive
mode. Use --force to skip confirmation prompts.
```

**After:** proceeds past the prompt and runs the normal deploy flow.

## Changes

- ``packages/cli/src/utils/prompts.ts``: remove the silent catch in ``getEnvironmentInteractive``; add ``force`` parameter to ``promptUseVerifiableBuild``; drop the now-unused ``isEnvironmentAvailable`` import
- ``packages/cli/src/commands/compute/app/deploy.ts``: pass ``flags.force`` to ``promptUseVerifiableBuild``
- ``packages/cli/src/commands/compute/app/upgrade.ts``: pass ``flags.force`` to ``promptUseVerifiableBuild``
- ``packages/cli/src/utils/__tests__/prompts.test.ts``: new regression tests (7 cases)

## Test plan

- [x] ``pnpm -C packages/cli run test`` — all 53 tests pass, including 7 new ones
- [x] ``pnpm -C packages/cli run lint`` clean on the four changed files
- [x] ``prettier --check`` clean on the four changed files
- [x] Manual repro of Bug 1 both ways (unknown env, unavailable env) — both now surface the real error
- [x] Manual repro of Bug 1 with valid env — ``ECLOUD_ENV=mainnet-alpha ecloud compute app info <id>`` returns app info end-to-end
- [x] Manual repro of Bug 2 — ``ecloud compute app deploy --image-ref ... --force`` proceeds past the "Build from verifiable source?" prompt and pulls the image

## Unblocks

Cutting ``v0.5.0`` stable without this patch will break:

- every ``ECLOUD_ENV=mainnet-alpha`` script (including the recipes in downstream CI and deployment docs)
- any image-ref-only deploy/upgrade flow in non-TTY contexts

Both repro cleanly on the current ``v0.5.0-dev.2`` build on npm.
