### PR TITLE
test(cli): add non-interactive smoke test and CI workflow

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -1,0 +1,54 @@
+name: CLI Smoke
+
+on:
+  pull_request:
+    paths:
+      - "packages/cli/**"
+      - "packages/sdk/**"
+      - ".github/workflows/cli-smoke.yml"
+      - "pnpm-lock.yaml"
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "20.x"
+
+jobs:
+  non-interactive:
+    name: Non-interactive smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK
+        working-directory: ./packages/sdk
+        run: pnpm run build
+
+      - name: Build CLI
+        working-directory: ./packages/cli
+        run: pnpm run build
+
+      - name: Run unit tests
+        working-directory: ./packages/cli
+        run: pnpm run test
+
+      - name: Non-interactive smoke
+        run: ./packages/cli/test/e2e/non-interactive.sh

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -261,7 +261,7 @@ export default class AppDeploy extends Command {
         // Interactive verifiable selection when --verifiable is not set.
         // If the user explicitly provided --dockerfile, assume they want the normal local-build flow.
         if (!flags.dockerfile) {
-          const useVerifiable = await promptUseVerifiableBuild();
+          const useVerifiable = await promptUseVerifiableBuild(flags.force);
           if (useVerifiable) {
             const sourceType = await promptVerifiableSourceType();
             verifiableMode = sourceType;

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -197,7 +197,7 @@ export default class AppUpgrade extends Command {
         // Interactive verifiable selection when --verifiable is not set.
         // If the user explicitly provided --dockerfile, assume they want the normal local-build flow.
         if (!flags.dockerfile) {
-          const useVerifiable = await promptUseVerifiableBuild();
+          const useVerifiable = await promptUseVerifiableBuild(flags.force);
           if (useVerifiable) {
             const sourceType = await promptVerifiableSourceType();
             verifiableMode = sourceType;

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getEnvironmentInteractive, promptUseVerifiableBuild } from "../prompts";
+
+/**
+ * Regression tests for two non-interactive mode bugs introduced in PR #126:
+ *
+ *   1. `getEnvironmentInteractive("mainnet-alpha")` in a dev build silently
+ *      swallowed the real error ("not available in this build type") and
+ *      surfaced the generic "Cannot prompt in non-interactive mode" message.
+ *   2. `promptUseVerifiableBuild()` had no knowledge of `--force`, so any
+ *      image-ref-only `app deploy` / `app upgrade` in non-TTY mode threw
+ *      `Cannot confirm "Build from verifiable source?" in non-interactive mode.
+ *      Use --force to skip confirmation prompts.` even when --force was set.
+ */
+describe("prompts non-interactive regressions", () => {
+  const origBuildType = process.env.BUILD_TYPE;
+  const origIsTTY = process.stdin.isTTY;
+
+  afterEach(() => {
+    if (origBuildType === undefined) delete process.env.BUILD_TYPE;
+    else process.env.BUILD_TYPE = origBuildType;
+    process.stdin.isTTY = origIsTTY;
+    vi.restoreAllMocks();
+  });
+
+  describe("getEnvironmentInteractive", () => {
+    it("returns the environment verbatim when it is valid and available", async () => {
+      process.env.BUILD_TYPE = "prod";
+      await expect(getEnvironmentInteractive("sepolia")).resolves.toBe("sepolia");
+      await expect(getEnvironmentInteractive("mainnet-alpha")).resolves.toBe("mainnet-alpha");
+    });
+
+    it("surfaces 'Unknown environment' for an unrecognized value", async () => {
+      process.env.BUILD_TYPE = "prod";
+      await expect(getEnvironmentInteractive("bogusenv")).rejects.toThrow(
+        /Unknown environment: bogusenv/,
+      );
+    });
+
+    it("surfaces 'not available in this build type' for envs missing from the current build", async () => {
+      // Bug 1 scenario: user installed a dev build, then ran a command with
+      // --environment mainnet-alpha. Previously they got the misleading
+      // "Cannot prompt in non-interactive mode" error. Now they get the
+      // real reason, referencing the build type.
+      //
+      // The SDK bakes BUILD_TYPE in at build time via tsup define, so
+      // `process.env.BUILD_TYPE` at runtime cannot flip it back to "dev".
+      // Instead, exercise the inverse: in the prod-built SDK used by tests,
+      // "sepolia-dev" is the environment that is *not* available — same
+      // code path, same error shape.
+      process.env.BUILD_TYPE = "prod";
+      await expect(getEnvironmentInteractive("sepolia-dev")).rejects.toThrow(
+        /not available in this build type/,
+      );
+    });
+
+    it("falls through to the interactive guard only when no environment is supplied", async () => {
+      process.env.BUILD_TYPE = "prod";
+      process.stdin.isTTY = false;
+      await expect(getEnvironmentInteractive(undefined)).rejects.toThrow(
+        /Cannot prompt in non-interactive mode/,
+      );
+    });
+  });
+
+  describe("promptUseVerifiableBuild", () => {
+    it("short-circuits to false when force is true, even in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      await expect(promptUseVerifiableBuild(true)).resolves.toBe(false);
+    });
+
+    it("throws the 'Use --force' guidance when force is false in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      await expect(promptUseVerifiableBuild(false)).rejects.toThrow(
+        /Cannot confirm "Build from verifiable source\?" in non-interactive mode\. Use --force/,
+      );
+    });
+
+    it("defaults force to false so existing callers still see the non-interactive error", async () => {
+      process.stdin.isTTY = false;
+      await expect(promptUseVerifiableBuild()).rejects.toThrow(
+        /Cannot confirm "Build from verifiable source\?" in non-interactive mode/,
+      );
+    });
+  });
+});

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -15,7 +15,6 @@ import { privateKeyToAccount } from "viem/accounts";
 import {
   getEnvironmentConfig,
   getAvailableEnvironments,
-  isEnvironmentAvailable,
   getAllAppsByDeveloper,
   getCategoryDescriptions,
   fetchTemplateCatalog,
@@ -152,8 +151,14 @@ function detectGitRepoInfo(): { repoUrl?: string; commitSha?: string } {
 
 /**
  * Prompt: "Build from verifiable source?" (only used when --verifiable is not set)
+ *
+ * When `force` is true (i.e. the user passed --force), skip the prompt entirely
+ * and return the default answer (false = regular build). Without this short-circuit,
+ * `confirmWithDefault` throws in non-interactive mode, which means --force on an
+ * image-ref-only deploy or upgrade was unusable in CI.
  */
-export async function promptUseVerifiableBuild(): Promise<boolean> {
+export async function promptUseVerifiableBuild(force: boolean = false): Promise<boolean> {
+  if (force) return false;
   return confirmWithDefault("Build from verifiable source?", false);
 }
 
@@ -1522,15 +1527,15 @@ export async function getPrivateKeyInteractive(privateKey?: string): Promise<str
  */
 export async function getEnvironmentInteractive(environment?: string): Promise<string> {
   if (environment) {
-    try {
-      getEnvironmentConfig(environment);
-      if (!isEnvironmentAvailable(environment)) {
-        throw new Error(`Environment ${environment} is not available in this build`);
-      }
-      return environment;
-    } catch {
-      // Invalid environment, continue to prompt
-    }
+    // Validate the explicit value and surface the real error to the user.
+    // getEnvironmentConfig throws a descriptive error for unknown environments
+    // AND for environments not available in the current build (dev vs prod).
+    // Previously we caught this silently and fell through to the interactive
+    // prompt, which in non-TTY mode surfaced the generic "Cannot prompt in
+    // non-interactive mode" error — hiding the real reason (e.g. "mainnet-alpha
+    // is not available in this build type" when using a dev build).
+    getEnvironmentConfig(environment);
+    return environment;
   }
 
   ensureInteractive("--environment or ECLOUD_ENV");

--- a/packages/cli/test/e2e/README.md
+++ b/packages/cli/test/e2e/README.md
@@ -1,0 +1,61 @@
+# CLI end-to-end tests
+
+These are black-box smoke tests that invoke the built CLI binary the same way
+CI and users do — via a child process with stdin closed. They complement the
+vitest unit tests in `packages/cli/src/**/__tests__/` by catching regressions
+that only surface once the full oclif command tree is loaded.
+
+## `non-interactive.sh`
+
+Non-TTY smoke test. Every command path that offers a non-interactive escape
+hatch (`--force`, explicit flag, env var) is invoked with `stdin </dev/null`
+and asserted to either:
+
+- succeed, or
+- fail with a specific, actionable error message
+
+The assertion that catches the most regressions is that commands **never**
+emit the generic `Cannot prompt in non-interactive mode` error when enough
+information has been provided via flags or env vars. That was the common
+shape of the regressions fixed in #130.
+
+### Run locally
+
+```bash
+pnpm -r build                                   # build SDK + CLI
+./packages/cli/test/e2e/non-interactive.sh
+```
+
+Expected runtime: ~10 seconds. Exits non-zero on any failed assertion.
+
+### Add a new assertion
+
+Every assertion follows the same shape:
+
+```bash
+out=$(run_cli compute app info "$DUMMY_APP_ID" --environment bogusenv)
+assert_match     "description" "expected pattern"     "$out"
+assert_not_match "description" "unwanted pattern"     "$out"
+```
+
+`run_cli` always returns zero so you can capture output regardless of the
+command's own exit code — assertions are pattern-based on the merged
+stdout + stderr.
+
+Prefer asserting both a positive match (the specific expected error) AND
+a negative match (no `"Cannot prompt in non-interactive mode"`) when
+testing error paths — the negative check is what catches the class of
+regressions that triggered this script.
+
+## Future tiers
+
+This script is Tier 1 of a planned three-tier validation stack:
+
+| Tier | What | When |
+|---|---|---|
+| 1 | This file — non-TTY smoke, no on-chain writes | every PR |
+| 2 | Full Sepolia deploy lifecycle on a dedicated funded wallet | nightly / pre-release |
+| 3 | Deploy-agent skill runbook executed end-to-end | pre-release validation |
+
+Tier 2 and Tier 3 need several upstream fixes first (`billing subscribe`
+non-interactive mode, `auth gen --store` keyring-replace flag, etc).

--- a/packages/cli/test/e2e/fixtures/minimal.env
+++ b/packages/cli/test/e2e/fixtures/minimal.env
@@ -1,0 +1,4 @@
+# Minimal env file used only by the non-interactive smoke script.
+# Contents are intentionally trivial — the goal is to exercise --env-file
+# loading code paths, not to deploy a real app.
+SMOKE_TEST=true

--- a/packages/cli/test/e2e/non-interactive.sh
+++ b/packages/cli/test/e2e/non-interactive.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Non-interactive smoke test for the ecloud CLI.
+#
+# Runs the CLI in non-TTY mode (stdin closed) against every command path that
+# offers a non-interactive escape hatch (flag, env var, --force) and asserts:
+#
+#   1. Commands that should succeed do succeed
+#   2. Commands that should fail do so with a specific, actionable error
+#      message -- never the generic "Cannot prompt in non-interactive mode"
+#   3. No command hangs past its timeout
+#
+# Intended to run in CI on every PR. Catches regressions like the ones fixed
+# in #130 (getEnvironmentInteractive swallowing the real error, and
+# promptUseVerifiableBuild ignoring --force).
+#
+# Usage (from repo root):
+#   ./packages/cli/test/e2e/non-interactive.sh
+#
+# Requires: the CLI to be built (pnpm -r build) before invocation.
+# =============================================================================
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+CLI="$REPO_ROOT/packages/cli/bin/run.js"
+FIXTURE_ENV="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fixtures/minimal.env"
+
+# Dummy app ID — deterministic, doesn't resolve to a real app. Used in info
+# calls where we expect to fail *before* the app lookup (at env validation).
+DUMMY_APP_ID="0x0000000000000000000000000000000000000000"
+
+if [ ! -x "$CLI" ]; then
+  echo "::error::CLI binary not found at $CLI. Run 'pnpm -r build' first."
+  exit 1
+fi
+
+FAIL=0
+PASS=0
+
+# -----------------------------------------------------------------------------
+# Assertion helpers. Each takes a short description for clear CI output.
+# -----------------------------------------------------------------------------
+
+assert_match() {
+  local desc="$1" pattern="$2" output="$3"
+  if echo "$output" | grep -qE -- "$pattern"; then
+    echo "  ✓ [$desc] output matched /$pattern/"
+    PASS=$((PASS + 1))
+  else
+    echo "::error::[$desc] output did not match /$pattern/"
+    echo "$output" | sed 's/^/    /' >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_match() {
+  local desc="$1" pattern="$2" output="$3"
+  if echo "$output" | grep -qE -- "$pattern"; then
+    echo "::error::[$desc] output unexpectedly matched /$pattern/"
+    echo "$output" | sed 's/^/    /' >&2
+    FAIL=$((FAIL + 1))
+  else
+    echo "  ✓ [$desc] output clean of /$pattern/"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# Run the CLI non-interactively with a timeout. Merges stderr into stdout.
+# Always returns 0 so tests can capture and inspect output regardless of the
+# command's own exit code.
+run_cli() {
+  timeout 20 "$CLI" "$@" </dev/null 2>&1 || true
+}
+
+section() { echo ""; echo "▸ $1"; }
+
+# -----------------------------------------------------------------------------
+# Test suite
+# -----------------------------------------------------------------------------
+
+section "Help surfaces load cleanly"
+for subcmd in "--version" "--help" "compute app info --help" "compute app deploy --help" "compute app upgrade --help" "billing status --help" "auth whoami --help"; do
+  # shellcheck disable=SC2086
+  out=$(run_cli $subcmd)
+  assert_not_match "'$subcmd' loaded without prompt error" "Cannot prompt in non-interactive" "$out"
+done
+
+section "Bug 1 — unknown environment surfaces a distinct error"
+# Invalid env name via ECLOUD_ENV
+out=$(ECLOUD_ENV=bogusenv run_cli compute app info "$DUMMY_APP_ID")
+assert_match     "bogusenv via ECLOUD_ENV"  "Unknown environment: bogusenv" "$out"
+assert_not_match "bogusenv via ECLOUD_ENV"  "Cannot prompt in non-interactive" "$out"
+
+# Invalid env name via --environment
+out=$(run_cli compute app info "$DUMMY_APP_ID" --environment bogusenv)
+assert_match     "bogusenv via --environment" "Unknown environment: bogusenv" "$out"
+assert_not_match "bogusenv via --environment" "Cannot prompt in non-interactive" "$out"
+
+section "Bug 1 — env unavailable in current build type surfaces the real reason"
+# The CLI in CI is built as prod by default, so sepolia-dev is the env that is
+# defined but not available. Asserting this here covers the mirror case of
+# "dev build running against mainnet-alpha" that originally triggered the bug.
+out=$(ECLOUD_ENV=sepolia-dev run_cli compute app info "$DUMMY_APP_ID")
+assert_match     "sepolia-dev in prod build"  "not available in this build type" "$out"
+assert_not_match "sepolia-dev in prod build"  "Cannot prompt in non-interactive" "$out"
+
+section "Bug 2 — deploy with image-ref only and --force skips the verifiable prompt"
+# Uses a non-existent image ref so the command will fail downstream (pull /
+# billing / network), but the assertion is specifically that it does NOT hit
+# the verifiable-source confirmation gate.
+out=$(run_cli compute app deploy \
+  --name smoke-image-ref-only \
+  --env-file "$FIXTURE_ENV" \
+  --image-ref "ghcr.io/ecloud-smoke-test/does-not-exist:latest" \
+  --instance-type g1-micro-1v \
+  --log-visibility public \
+  --resource-usage-monitoring enable \
+  --skip-profile \
+  --description "non-interactive smoke" \
+  --force)
+assert_not_match "image-ref deploy with --force" 'Cannot confirm "Build from verifiable source\?"' "$out"
+
+section "Bug 2 — upgrade with image-ref only and --force skips the verifiable prompt"
+out=$(run_cli compute app upgrade "$DUMMY_APP_ID" \
+  --env-file "$FIXTURE_ENV" \
+  --image-ref "ghcr.io/ecloud-smoke-test/does-not-exist:latest" \
+  --instance-type g1-micro-1v \
+  --log-visibility public \
+  --resource-usage-monitoring enable \
+  --force)
+assert_not_match "image-ref upgrade with --force" 'Cannot confirm "Build from verifiable source\?"' "$out"
+
+section "Auth — whoami runs non-interactively without crashing"
+# whoami has no side effects and no prompts regardless of keyring state.
+out=$(run_cli auth whoami)
+assert_not_match "auth whoami" "Cannot prompt in non-interactive" "$out"
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "============================================================"
+echo "  Non-interactive smoke: $PASS passed, $FAIL failed"
+echo "============================================================"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a black-box CLI smoke test that invokes the built binary with `stdin </dev/null` and asserts every command path with a non-interactive escape hatch (`--force`, explicit flag, env var) either succeeds or fails with a specific, actionable error — never the generic `Cannot prompt in non-interactive mode` fallback.

**This would have caught both regressions fixed in #130.** Verified by temporarily checking out `packages/cli/src` from `origin/master` and running the script — **8 passes, 8 failures**, exactly matching the two bugs #130 fixes. On the patched branch: **16/16 pass**.

## Why this belongs in CI

The two bugs in #130 (`getEnvironmentInteractive` swallowing the real error, `promptUseVerifiableBuild` ignoring `--force`) shipped in `v0.5.0-dev.2` and silently broke every `ECLOUD_ENV=mainnet-alpha` script and every image-ref-only deploy in non-TTY contexts. Neither has unit tests that would catch the regression at the binary-invocation level — the unit tests in #130 cover the functions directly but not how they compose through the full oclif command tree.

This script closes that gap. It runs in ~10 seconds, requires no secrets, does no on-chain writes.

## What it covers

| Assertion | Catches |
|---|---|
| `--help` / `--version` / subcommand help all load without prompt errors | Broken oclif command tree, missing ensureInteractive guards on help paths |
| `ECLOUD_ENV=bogusenv` emits `Unknown environment: bogusenv` | Bug 1 (unknown env surfaces generic error) |
| `--environment bogusenv` emits `Unknown environment: bogusenv` | Bug 1 via flag instead of env var |
| `ECLOUD_ENV=sepolia-dev` on a prod build emits `not available in this build type` | Bug 1 mirror case (env valid but wrong build type) |
| Deploy with `--image-ref` only + `--force` does NOT emit `Cannot confirm "Build from verifiable source?"` | Bug 2 |
| Upgrade with `--image-ref` only + `--force` does NOT emit `Cannot confirm "Build from verifiable source?"` | Bug 2 mirror case on upgrade |
| `auth whoami` runs cleanly | Sanity check for a command with no prompts |

## Layout

```
.github/workflows/cli-smoke.yml         # PR + master push workflow
packages/cli/test/e2e/non-interactive.sh # the assertion script
packages/cli/test/e2e/fixtures/minimal.env
packages/cli/test/e2e/README.md         # local usage + how to extend
```

The workflow also runs `pnpm -C packages/cli run test` so the existing vitest suite finally has a PR-level gate it didn't have before.

## Follow-ups the README sketches

This is Tier 1 of a three-tier validation stack I'd like to build out over time:

| Tier | What | When |
|---|---|---|
| 1 | This PR — non-TTY smoke, no on-chain writes | every PR |
| 2 | Full Sepolia deploy lifecycle on a dedicated funded wallet | nightly / pre-release |
| 3 | Deploy-agent skill runbook executed end-to-end | pre-release validation |

Tier 2 and Tier 3 are blocked on a couple of upstream fixes (`billing subscribe` has no non-interactive flag, `auth gen --store` crashes when replacing an existing keyring key). Happy to file issues for those.

## Dependencies

**Stacked on #130.** The smoke script asserts the fixes that #130 makes. Against unpatched `master` the script correctly fails (proving the assertions work). Merge #130 first; this will rebase cleanly onto master after that.

## Test plan

- [x] Against the patched branch (`fix/non-interactive-regressions`): 16/16 pass
- [x] Against `origin/master` (unpatched): 8 pass, 8 fail — the 8 failures match Bug 1 and Bug 2 exactly
- [x] `shellcheck packages/cli/test/e2e/non-interactive.sh` clean
- [x] Script completes in ~10 seconds locally
- [ ] CI run on this PR confirms the workflow resolves all action SHAs and finishes green
