### PR TITLE
feat(cli,sdk): redeem promo codes via `billing top-up --code` (RND-557)

### DIFF
--- a/packages/cli/src/commands/billing/__tests__/top-up.test.ts
+++ b/packages/cli/src/commands/billing/__tests__/top-up.test.ts
@@ -26,6 +26,7 @@ describe("ecloud billing top-up", () => {
     getStatus: ReturnType<typeof vi.fn>;
     getTopUpInfo: ReturnType<typeof vi.fn>;
     topUp: ReturnType<typeof vi.fn>;
+    redeemCode: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -37,6 +38,7 @@ describe("ecloud billing top-up", () => {
       getStatus: vi.fn(),
       getTopUpInfo: vi.fn(),
       topUp: vi.fn(),
+      redeemCode: vi.fn(),
     };
     (createBillingClient as ReturnType<typeof vi.fn>).mockResolvedValue(mockBilling);
 
@@ -226,5 +228,36 @@ describe("ecloud billing top-up", () => {
     expect(fullOutput).toContain("Transaction confirmed");
     // Will timeout on polling since status always errors
     expect(fullOutput).toContain("Credits haven't appeared yet");
+  });
+
+  it("--code: happy path prints granted amount and new balance", async () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 90 * 24 * 3600;
+    mockBilling.redeemCode.mockResolvedValue({
+      code: "LAUNCH50",
+      grantedAmount: 50,
+      remainingCredits: 55,
+      expiresAt,
+    });
+
+    const cmd = createCommand({ code: "LAUNCH50" });
+    await cmd.run();
+    const fullOutput = logOutput.join("\n");
+
+    expect(mockBilling.redeemCode).toHaveBeenCalledWith({ code: "LAUNCH50", productId: "compute" });
+    expect(fullOutput).toContain("Redeem promotion code");
+    expect(fullOutput).toContain("LAUNCH50");
+    expect(fullOutput).toContain("$50.00");
+    expect(fullOutput).toContain("$55.00");
+    // USDC flow must not run
+    expect(mockBilling.getTopUpInfo).not.toHaveBeenCalled();
+    expect(mockBilling.topUp).not.toHaveBeenCalled();
+  });
+
+  it("--code: surfaces friendly error on 404", async () => {
+    mockBilling.redeemCode.mockRejectedValue(new Error("BillingAPI request failed: 404 Error - Promotion code not found or inactive"));
+
+    const cmd = createCommand({ code: "BADCODE" });
+    await expect(cmd.run()).rejects.toThrow(/not valid|inactive|already redeemed/i);
+    expect(mockBilling.topUp).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/billing/top-up.ts
+++ b/packages/cli/src/commands/billing/top-up.ts
@@ -23,7 +23,7 @@ const POLL_INTERVAL_MS = 5_000;
 const POLL_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
 
 export default class BillingTopUp extends Command {
-  static description = "Purchase EigenCompute credits with USDC";
+  static description = "Purchase EigenCompute credits with USDC, or redeem a promo code";
 
   static flags = {
     ...commonFlags,
@@ -34,6 +34,10 @@ export default class BillingTopUp extends Command {
     account: Flags.string({
       required: false,
       description: "Target account address for purchaseCreditsFor (defaults to your wallet)",
+    }),
+    code: Flags.string({
+      required: false,
+      description: "Redeem a promotion code for promotional credits (skips USDC flow)",
     }),
     product: Flags.string({
       required: false,
@@ -50,6 +54,10 @@ export default class BillingTopUp extends Command {
 
       // Create billing client
       const billing = await createBillingClient(flags);
+
+      if (flags.code) {
+        return this.redeemCode(billing, flags.product as "compute", flags.code);
+      }
 
       const walletAddress = billing.address;
       const targetAccount = (flags.account as Address) ?? walletAddress;
@@ -175,5 +183,40 @@ export default class BillingTopUp extends Command {
       );
       this.log(`  ${chalk.gray("Check your balance:")} ecloud billing status\n`);
     });
+  }
+
+  private async redeemCode(
+    billing: Awaited<ReturnType<typeof createBillingClient>>,
+    productId: "compute",
+    code: string,
+  ) {
+    this.log(`\n${chalk.bold("Redeem promotion code")}`);
+    this.log(`${chalk.gray("─".repeat(45))}`);
+    this.log(`\n  ${chalk.bold("Wallet:")}  ${billing.address}`);
+    this.log(`  ${chalk.bold("Code:")}    ${code}`);
+
+    try {
+      const result = await billing.redeemCode({ code, productId });
+      this.log(
+        `\n  ${chalk.green("✓")} Redeemed ${chalk.bold(code)}: ${chalk.cyan(`$${result.grantedAmount.toFixed(2)}`)} in credits`,
+      );
+      if (result.remainingCredits !== undefined) {
+        this.log(`  ${chalk.bold("Balance:")} ${chalk.cyan(`$${result.remainingCredits.toFixed(2)}`)}`);
+      }
+      if (result.expiresAt) {
+        const expiry = new Date(result.expiresAt * 1000).toLocaleDateString();
+        this.log(`  ${chalk.gray(`Credits expire: ${expiry}`)}`);
+      }
+      this.log();
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      if (msg.includes("404") || msg.toLowerCase().includes("not found")) {
+        this.error(`Code "${code}" is not valid, inactive, or already redeemed.`);
+      }
+      if (msg.includes("422")) {
+        this.error(`Code "${code}" is not a fixed-amount credit code (percent-off codes are not supported).`);
+      }
+      this.error(`Failed to redeem code: ${msg}`);
+    }
   }
 }

--- a/packages/sdk/src/client/common/types/index.ts
+++ b/packages/sdk/src/client/common/types/index.ts
@@ -395,6 +395,17 @@ export interface NoActiveSubscriptionResponse {
 
 export type CancelResponse = CancelSuccessResponse | NoActiveSubscriptionResponse;
 
+export interface RedeemCodeRequest {
+  code: string;
+}
+
+export interface RedeemCodeResponse {
+  code: string;
+  grantedAmount: number;
+  remainingCredits?: number;
+  expiresAt?: number;
+}
+
 export interface ProductSubscriptionResponse {
   productId: ProductID;
   subscriptionStatus: SubscriptionStatus;

--- a/packages/sdk/src/client/common/utils/billingapi.ts
+++ b/packages/sdk/src/client/common/utils/billingapi.ts
@@ -18,6 +18,7 @@ import {
   CreateSubscriptionResponse,
   GetSubscriptionOptions,
   ProductSubscriptionResponse,
+  RedeemCodeResponse,
 } from "../types";
 import { calculateBillingAuthSignature } from "./auth";
 import { BillingEnvironmentConfig } from "../types";
@@ -174,6 +175,15 @@ export class BillingApiClient {
   async cancelSubscription(productId: ProductID = "compute"): Promise<void> {
     const endpoint = `${this.config.billingApiServerURL}/products/${productId}/subscription`;
     await this.makeAuthenticatedRequest(endpoint, "DELETE", productId);
+  }
+
+  async redeemCode(
+    code: string,
+    productId: ProductID = "compute",
+  ): Promise<RedeemCodeResponse> {
+    const endpoint = `${this.config.billingApiServerURL}/products/${productId}/redeem`;
+    const resp = await this.makeAuthenticatedRequest(endpoint, "POST", productId, { code });
+    return resp.json();
   }
 
   // ==========================================================================

--- a/packages/sdk/src/client/modules/billing/index.ts
+++ b/packages/sdk/src/client/modules/billing/index.ts
@@ -23,6 +23,7 @@ import type {
   SubscribeResponse,
   CancelResponse,
   ProductSubscriptionResponse,
+  RedeemCodeResponse,
 } from "../../common/types";
 
 export interface TopUpOpts {
@@ -44,6 +45,11 @@ export interface TopUpInfo {
   currentAllowance: bigint;
 }
 
+export interface RedeemCodeOpts {
+  code: string;
+  productId?: ProductID;
+}
+
 export interface BillingModule {
   address: Address;
   subscribe: (opts?: SubscriptionOpts) => Promise<SubscribeResponse>;
@@ -53,6 +59,8 @@ export interface BillingModule {
   getTopUpInfo: () => Promise<TopUpInfo>;
   /** Purchase credits with USDC on-chain */
   topUp: (opts: TopUpOpts) => Promise<TopUpResult>;
+  /** Redeem a promotion code for promotional credits */
+  redeemCode: (opts: RedeemCodeOpts) => Promise<RedeemCodeResponse>;
 }
 
 export interface BillingModuleConfig {
@@ -278,6 +286,21 @@ export function createBillingModule(config: BillingModuleConfig): BillingModule 
           return {
             type: "canceled" as const,
           };
+        },
+      );
+    },
+
+    async redeemCode(opts) {
+      return withSDKTelemetry(
+        {
+          functionName: "redeemCode",
+          skipTelemetry,
+          properties: { productId: opts.productId || "compute" },
+        },
+        async () => {
+          const productId: ProductID = opts.productId || "compute";
+          logger.debug(`Redeeming code for ${productId}...`);
+          return billingApi.redeemCode(opts.code, productId);
         },
       );
     },


### PR DESCRIPTION
## Summary

Adds `--code` to `ecloud billing top-up` so existing subscribers can apply a Stripe promo code. Today there's no way to do this — the Stripe Checkout "Add code" box only shows on initial subscribe.

Usage (agent-friendly, non-interactive, no prompts):
```
$ ecloud billing top-up --code LAUNCH50

Redeem promotion code
─────────────────────────────────────────────

  Wallet:  0x6d4f13BD87DD441B3Fc8d94349C72EeFe27684e8
  Code:    LAUNCH50

  ✓ Redeemed LAUNCH50: $50.00 in credits
  Balance: $55.00
  Credits expire: 7/28/2026
```

Pairs with API PR: https://github.com/Layr-Labs/ecloud-billing-api/pull/41

## Scope

```
 packages/cli/src/commands/billing/__tests__/top-up.test.ts | 31 +++++++++++++++
 packages/cli/src/commands/billing/top-up.ts                | 47 +++++++++++++++++++++-
 packages/sdk/src/client/common/types/index.ts              | 11 ++++++
 packages/sdk/src/client/common/utils/billingapi.ts         | 10 ++++-
 packages/sdk/src/client/modules/billing/index.ts           | 23 ++++++++++-
 5 files changed, 121 insertions(+), 1 deletion(-)
```

No changes to `subscribe`, `status`, `cancel`, or the existing USDC top-up flow. `--code` short-circuits before any on-chain interaction, so nothing in the USDC path is touched.

## How to validate

**Unit tests:**
```
pnpm --filter @layr-labs/ecloud-cli test
```
All 55 tests pass (including 2 new `--code` cases).

**Manual dry-run (no Stripe needed):**
```
ecloud billing top-up --code ANY --help    # shows flag description
```

**End-to-end (against Stripe test mode + local billing-api from #41):**
1. Check out `feat/redeem-code` on `ecloud-billing-api` and `make run` with a Stripe test key.
2. Create a Coupon ($5 off, once) and a Promotion Code (e.g., `TEST5`, `max_redemptions=1`) in the Stripe Dashboard (test mode).
3. Build the CLI: `pnpm --filter @layr-labs/ecloud-cli build`
4. Run against a subscribed wallet:
   ```
   ecloud billing top-up --code TEST5
   ```
   Expect: `✓ Redeemed TEST5: $5.00 in credits` + new balance + expiry.
5. Second attempt (same wallet, same code) → Stripe idempotency re-returns the same grant silently.
6. Different wallet, same code → friendly error: `Code "TEST5" is not valid, inactive, or already redeemed.` (because Promotion Code got deactivated after the first burn).
7. Percent-off code → `Code "..." is not a fixed-amount credit code (percent-off codes are not supported).`
8. Confirm via `ecloud billing status` — `Remaining Credits` should reflect the new amount.

## Not in this PR

- New menu / interactive picker — deliberately kept flag-driven for CLI + agent ergonomics. Can layer an inquirer prompt later.
- CC top-up — separate open work.

## Linear

RND-557 — https://linear.app/eigenlabs/issue/RND-557/add-couponcredit-code-redemption-to-ecloud-billing-top-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)