### PR TITLE
feat(sdk): add ECLOUD_API_URL env var to override API base URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ yarn-error.log*
 # oclif autocomplete cache (if enabled later)
 _autocomplete/
 .feature-clone
+
+# local agent worktrees
+.claude/

--- a/packages/sdk/src/client/common/config/environment.test.ts
+++ b/packages/sdk/src/client/common/config/environment.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBillingEnvironmentConfig, getEnvironmentConfig } from "./environment";
+
+describe("environment config ECLOUD_API_URL override", () => {
+  const originalApiUrl = process.env.ECLOUD_API_URL;
+  const originalBuildType = process.env.BUILD_TYPE;
+
+  beforeEach(() => {
+    // Ensure sepolia-dev is an available environment for getEnvironmentConfig()
+    process.env.BUILD_TYPE = "dev";
+    delete process.env.ECLOUD_API_URL;
+  });
+
+  afterEach(() => {
+    if (originalApiUrl === undefined) delete process.env.ECLOUD_API_URL;
+    else process.env.ECLOUD_API_URL = originalApiUrl;
+    if (originalBuildType === undefined) delete process.env.BUILD_TYPE;
+    else process.env.BUILD_TYPE = originalBuildType;
+  });
+
+  it("uses built-in userApiServerURL when ECLOUD_API_URL is unset", () => {
+    const cfg = getEnvironmentConfig("sepolia-dev");
+    expect(cfg.userApiServerURL).toBe("https://userapi-compute-sepolia-dev.eigencloud.xyz");
+  });
+
+  it("overrides userApiServerURL when ECLOUD_API_URL is set", () => {
+    process.env.ECLOUD_API_URL =
+      "https://ecloud-platform-sepolia-dev.internal.eigencompute-testnet.eigenlabshq.net";
+    const cfg = getEnvironmentConfig("sepolia-dev");
+    expect(cfg.userApiServerURL).toBe(
+      "https://ecloud-platform-sepolia-dev.internal.eigencompute-testnet.eigenlabshq.net",
+    );
+  });
+
+  it("strips a single trailing slash from ECLOUD_API_URL", () => {
+    process.env.ECLOUD_API_URL = "https://example.com/";
+    expect(getEnvironmentConfig("sepolia-dev").userApiServerURL).toBe("https://example.com");
+  });
+
+  it("strips multiple trailing slashes from ECLOUD_API_URL", () => {
+    process.env.ECLOUD_API_URL = "https://example.com///";
+    expect(getEnvironmentConfig("sepolia-dev").userApiServerURL).toBe("https://example.com");
+  });
+
+  it("treats an empty ECLOUD_API_URL as unset", () => {
+    process.env.ECLOUD_API_URL = "";
+    expect(getEnvironmentConfig("sepolia-dev").userApiServerURL).toBe(
+      "https://userapi-compute-sepolia-dev.eigencloud.xyz",
+    );
+  });
+
+  it("treats a whitespace-only ECLOUD_API_URL as unset", () => {
+    process.env.ECLOUD_API_URL = "   ";
+    expect(getEnvironmentConfig("sepolia-dev").userApiServerURL).toBe(
+      "https://userapi-compute-sepolia-dev.eigencloud.xyz",
+    );
+  });
+
+  it("leaves other environment fields untouched when overriding", () => {
+    process.env.ECLOUD_API_URL = "https://example.com";
+    const cfg = getEnvironmentConfig("sepolia-dev");
+    expect(cfg.name).toBe("sepolia");
+    expect(cfg.kmsServerURL).toBe("http://10.128.0.57:8080");
+    expect(cfg.defaultRPCURL).toBe("https://ethereum-sepolia-rpc.publicnode.com");
+  });
+
+  it("uses built-in billingApiServerURL when ECLOUD_API_URL is unset", () => {
+    expect(getBillingEnvironmentConfig("dev").billingApiServerURL).toBe(
+      "https://billingapi-dev.eigencloud.xyz",
+    );
+    expect(getBillingEnvironmentConfig("prod").billingApiServerURL).toBe(
+      "https://billingapi.eigencloud.xyz",
+    );
+  });
+
+  it("overrides billingApiServerURL when ECLOUD_API_URL is set (dev)", () => {
+    process.env.ECLOUD_API_URL = "https://example.com";
+    expect(getBillingEnvironmentConfig("dev").billingApiServerURL).toBe("https://example.com");
+  });
+
+  it("overrides billingApiServerURL when ECLOUD_API_URL is set (prod)", () => {
+    process.env.ECLOUD_API_URL = "https://example.com";
+    expect(getBillingEnvironmentConfig("prod").billingApiServerURL).toBe("https://example.com");
+  });
+});

--- a/packages/sdk/src/client/common/config/environment.ts
+++ b/packages/sdk/src/client/common/config/environment.ts
@@ -78,6 +78,25 @@ const CHAIN_ID_TO_ENVIRONMENT: Record<string, string> = {
 };
 
 /**
+ * Read the ECLOUD_API_URL runtime override, if set.
+ *
+ * When set, this overrides both `userApiServerURL` and `billingApiServerURL`
+ * so that all API traffic is directed at a single host. This is the intended
+ * way to point the CLI/SDK at an ecloud-platform deployment (which serves
+ * both the compute-tee UserAPI and BillingAPI surfaces from one host via its
+ * legacy-compatibility shim), or at any local/staging server.
+ *
+ * Trailing slashes are trimmed so consumers can safely do `${base}/path`.
+ * Empty strings are treated as unset.
+ */
+function getApiUrlOverride(): string | undefined {
+  const raw = process.env.ECLOUD_API_URL;
+  if (!raw) return undefined;
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
  * Get environment configuration
  */
 export function getEnvironmentConfig(environment: string, chainID?: bigint): EnvironmentConfig {
@@ -110,9 +129,12 @@ export function getEnvironmentConfig(environment: string, chainID?: bigint): Env
       ? SEPOLIA_CHAIN_ID
       : MAINNET_CHAIN_ID);
 
+  const apiUrlOverride = getApiUrlOverride();
+
   return {
     ...env,
     chainID: BigInt(resolvedChainID),
+    ...(apiUrlOverride ? { userApiServerURL: apiUrlOverride } : {}),
   };
 }
 
@@ -126,6 +148,10 @@ export function getBillingEnvironmentConfig(build: "dev" | "prod"): {
   const config = BILLING_ENVIRONMENTS[build];
   if (!config) {
     throw new Error(`Unknown billing environment: ${build}`);
+  }
+  const apiUrlOverride = getApiUrlOverride();
+  if (apiUrlOverride) {
+    return { billingApiServerURL: apiUrlOverride };
   }
   return config;
 }


### PR DESCRIPTION
## Summary

Adds a runtime override that lets the CLI/SDK target an alternate compute-tee-compatible host (e.g. the new ecloud-platform deployment) via a single env var, with zero changes to HTTP call sites or request/response shapes.

```bash
export ECLOUD_API_URL=https://ecloud-platform-sepolia-dev.internal.eigencompute-testnet.eigenlabshq.net
ecloud compute app list
```

## Why

ecloud-platform exposes a legacy-compat HTTP shim that serves every compute-tee path the CLI currently uses (`/info`, `/status`, `/skus`, `/apps/:id`, `/apps/:id/profile`, `/logs/:id`, `/auth/siwe/*`, `/builds*`, `/products/:id/subscription`). To point the existing CLI at it, we only need to redirect the base URL — no SDK rewrite needed.

## Design

- Override lives in the two config resolvers (`getEnvironmentConfig`, `getBillingEnvironmentConfig`) so every downstream client (`UserApiClient`, `BillingApiClient`, `BuildApiClient` — which all read from these configs) picks it up with no call-site changes.
- One env var overrides both UserAPI and Billing API URLs — ecloud-platform serves both from the same host, and keeping them in lockstep avoids a footgun.
- Trailing slashes are trimmed so `https://host/` and `https://host` both work.
- Empty/whitespace values are treated as unset.
- No CLI flag added; matches existing convention that no base URL is flag-configurable.

## Non-goals

- No migration to ecloud-platform's native `/v1/*` gRPC-gateway surface. That would require new shapes (different Build fields, InstanceType instead of SKU, `PATCH /v1/apps/{addr}` for profile, etc.) and still leaves gaps (no native equivalents for `/logs/{app_id}`, `/builds/verify/{id}`, `/builds/{id}/logs`). Deferred.
- Default URLs for `sepolia-dev`/`sepolia`/`mainnet-alpha` unchanged. Flip those separately once each env has a stable ecloud-platform endpoint.

## Tests

10 new vitest cases in `packages/sdk/src/client/common/config/environment.test.ts` covering:
- override on/off behavior for both user and billing API URLs
- trailing-slash trimming (single and multiple)
- empty and whitespace-only values treated as unset
- unrelated fields (kmsServerURL, defaultRPCURL, name) untouched by override

All 23 SDK tests pass (13 pre-existing + 10 new). SDK typecheck clean. New files are prettier-clean and eslint-clean.

## Caveat to verify post-merge

ecloud-platform's session cookie is named `ecloud_session` (vs compute-tee's `billing_session`). The SDK forwards Set-Cookie values verbatim through its fetch/axios layer, so it should Just Work, but worth smoke-testing a SIWE login flow against the new host to confirm.