### PR TITLE
fix(sdk): bounded retry around tls-keygen for transient ACME 5xx

### DIFF
--- a/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
+++ b/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
@@ -60,11 +60,41 @@ setup_tls() {
     fi
     
     echo "compute-source-env.sh: Obtaining TLS certificate using $challenge challenge..."
-    # Pass the API URL for certificate persistence
-    if ! MNEMONIC="$mnemonic" DOMAIN="$domain" API_URL="{{userAPIURL}}" /usr/local/bin/tls-keygen \
-        -challenge "$challenge" \
-        $staging_flag; then
-        echo "compute-source-env.sh: ERROR - Failed to obtain TLS certificate"
+    # Bounded retry around tls-keygen to absorb transient ACME 5xx
+    # responses (Let's Encrypt staging in particular returns
+    # "Service busy; retry later" intermittently, and tls-keygen
+    # has no internal retry — a single 503 today will terminate
+    # the VM). Total attempts capped at 3 with 1s/5s/15s backoff
+    # to stay well under LE's failed-auth rate limit
+    # (5/hour/account/host on prod, 60/hour on staging) in the
+    # worst case of sustained failure across reprovisions.
+    # Pass the API URL for certificate persistence.
+    tls_attempt=1
+    tls_max_attempts=3
+    tls_ok=0
+    while [ "$tls_attempt" -le "$tls_max_attempts" ]; do
+        if [ "$tls_attempt" -gt 1 ]; then
+            echo "compute-source-env.sh: tls-keygen attempt $tls_attempt/$tls_max_attempts"
+        fi
+        if MNEMONIC="$mnemonic" DOMAIN="$domain" API_URL="{{userAPIURL}}" /usr/local/bin/tls-keygen \
+            -challenge "$challenge" \
+            $staging_flag; then
+            tls_ok=1
+            break
+        fi
+        if [ "$tls_attempt" -lt "$tls_max_attempts" ]; then
+            case "$tls_attempt" in
+                1) tls_delay=1 ;;
+                2) tls_delay=5 ;;
+                *) tls_delay=15 ;;
+            esac
+            echo "compute-source-env.sh: tls-keygen failed on attempt $tls_attempt, retrying in ${tls_delay}s..."
+            sleep "$tls_delay"
+        fi
+        tls_attempt=$((tls_attempt + 1))
+    done
+    if [ "$tls_ok" != "1" ]; then
+        echo "compute-source-env.sh: ERROR - Failed to obtain TLS certificate after $tls_max_attempts attempts"
         echo "compute-source-env.sh: Certificate issuance failed for $domain"
         exit 1
     fi

--- a/packages/sdk/src/client/common/templates/scriptTemplate.test.ts
+++ b/packages/sdk/src/client/common/templates/scriptTemplate.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { processScriptTemplate } from "./scriptTemplate";
+
+describe("compute-source-env.sh template", () => {
+  const rendered = processScriptTemplate({
+    kmsServerURL: "http://test-kms:8080",
+    userAPIURL: "http://test-api.example",
+  });
+
+  it("renders handlebars placeholders", () => {
+    expect(rendered).toContain("http://test-kms:8080");
+    expect(rendered).toContain("http://test-api.example");
+    expect(rendered).not.toContain("{{kmsServerURL}}");
+    expect(rendered).not.toContain("{{userAPIURL}}");
+  });
+
+  describe("tls-keygen ACME retry", () => {
+    // tls-keygen has no internal retry on transient ACME 5xx. A
+    // single "Service busy; retry later" from Let's Encrypt (common
+    // on staging) would otherwise terminate the VM. The template
+    // wraps the binary invocation in a bounded retry loop — these
+    // tests guard the shape of that loop.
+
+    it("caps attempts at a small finite number", () => {
+      // Look for `tls_max_attempts=N` and assert N is a sane small
+      // value. The exact number is implementation detail, but a
+      // regression that unbounded it (or raised it above the
+      // per-hour LE failed-auth rate limit of 5 for prod) would be
+      // caught here.
+      const match = rendered.match(/tls_max_attempts=(\d+)/);
+      expect(match, "tls_max_attempts must be set in template").not.toBeNull();
+      const n = Number(match![1]);
+      expect(n).toBeGreaterThanOrEqual(2);
+      expect(n).toBeLessThanOrEqual(5);
+    });
+
+    it("retries on failure", () => {
+      // A retry loop must both invoke tls-keygen and contain a
+      // sleep branch — otherwise it's not really retrying.
+      expect(rendered).toMatch(/while\s*\[\s*"\$tls_attempt"/);
+      expect(rendered).toMatch(/\/usr\/local\/bin\/tls-keygen/);
+      expect(rendered).toMatch(/sleep\s+"\$tls_delay"/);
+    });
+
+    it("fails hard after exhausting attempts", () => {
+      // On sustained failure the template must still `exit 1` so
+      // the Confidential Space launcher sees the same failure
+      // signal as before (VM terminates, platform reacts). A retry
+      // loop that swallowed the final failure would be worse than
+      // no retry at all.
+      expect(rendered).toMatch(
+        /Failed to obtain TLS certificate after \$tls_max_attempts attempts[\s\S]*?exit 1/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`tls-keygen` has no internal retry on transient ACME failures. A single Let's Encrypt 503 ("Service busy; retry later") — common on staging, occasional on prod — fails the TLS setup in `compute-source-env.sh` and terminates the VM via `exit 1`, forcing a full re-provision by the platform.

Observed today on a fresh VM during dev E2E testing:

```
2026/05/05 21:08:01 [INFO] Unable to get the authorization for https://acme-staging-v02.api.letsencrypt.org/acme/authz/...
  acme: error: 503 :: POST :: ... :: urn:ietf:params:acme:error:rateLimited :: Service busy; retry later.
2026/05/05 21:08:01 error obtaining certificate: obtain certificate: error: one or more domains had a problem:
  [...] failed to initiate challenge: acme: error: 503 ... :: Service busy; retry later.
compute-source-env.sh: ERROR - Failed to obtain TLS certificate
compute-source-env.sh: Certificate issuance failed for ...
```

One transient 503 → full VM teardown + reprovision. The very next attempt (same image, same config) succeeded first try.

## Fix

Wrap the `tls-keygen` invocation in the entrypoint template with a bounded retry loop: up to **3 total attempts**, **1s then 5s backoff** between retries.

The cap of 3 is deliberate: LE's failed-auth rate limit is **5/hour/account/host** on prod (60/hour on staging). 3 tries per VM stays well below that ceiling even across consecutive reprovisions on a bad afternoon.

## Non-goals / preserved behavior

- **Exit signal unchanged**: on sustained failure the loop still `exit 1`s with the same `"Certificate issuance failed for $domain"` message, so the Confidential Space launcher reacts identically to before. A retry loop that swallowed the final failure would be strictly worse than no retry.
- **Success path unchanged**: first-try success skips all retry machinery, identical wall-clock.
- **No tls-keygen source changes.** `tls-keygen` is a pre-built binary in `packages/sdk/tools/`; the right long-term fix is for that binary to handle transient ACME 5xx internally. This shim absorbs the failure mode in the CLI template without requiring coordinated binary + CLI releases.

## Test coverage

New `scriptTemplate.test.ts` guards the retry-loop shape:

- finite attempt cap (2–5 range allowed, currently 3)
- while-loop actually invokes tls-keygen and actually sleeps between attempts
- final exhaustion branch still `exit 1`s with `after $tls_max_attempts attempts` message

Tests are intentionally **not wired to a CI command** in this PR — `packages/sdk` has no `test` script today and multiple `*.test.ts` files already sit unwired (`environment.test.ts`, `attest-client.test.ts`, `jwt-provider.test.ts`). Wiring vitest is orthogonal plumbing; keeping scope narrow here. Tests will run the moment the plumbing lands.

## Manual validation

Rendered the template, sliced `setup_tls()` into a standalone shim, drove it under `dash` against a scripted fake tls-keygen. All three scenarios:

| Scenario | Invocations | Elapsed | rc |
|---|---|---|---|
| success first try | 1 | ~2s | 0 |
| fail-once-then-succeed | 2 (1s apart) | ~3s | 0 |
| sustained failure | 3 (t, t+1s, t+6s) | ~7s | 1 |

Also `dash -n` + `bash -n` on the fully rendered script — both clean.