### PR TITLE
feat(sdk): stamp eigenx_container_contract=v1 label on layered images

### DIFF
--- a/packages/sdk/src/client/common/templates/Dockerfile.layered.tmpl
+++ b/packages/sdk/src/client/common/templates/Dockerfile.layered.tmpl
@@ -63,6 +63,7 @@ LABEL tee.launch_policy.allow_env_override=ECLOUD_PD_EXPECTED
 
 LABEL eigenx_cli_version={{ecloudCLIVersion}}
 LABEL eigenx_vm_image=eigen
+LABEL eigenx_container_contract=v1
 
 {{#if includeTLS}}
 # Expose both HTTP and HTTPS ports for Caddy

--- a/packages/sdk/src/client/common/templates/dockerfileTemplate.test.ts
+++ b/packages/sdk/src/client/common/templates/dockerfileTemplate.test.ts
@@ -52,4 +52,9 @@ describe("Dockerfile.layered.tmpl", () => {
     const rendered = render(base);
     expect(rendered).toContain("LABEL eigenx_vm_image=eigen");
   });
+
+  it("stamps eigenx_container_contract=v1 for prewarm-detach eligibility gate", () => {
+    const rendered = render(base);
+    expect(rendered).toContain("LABEL eigenx_container_contract=v1");
+  });
 });


### PR DESCRIPTION
## What

Stamps `LABEL eigenx_container_contract=v1` on every image produced by the CLI-side layerer (`Dockerfile.layered.tmpl` in the SDK). This is the CLI half of the eligibility mechanism described in ecloud-platform's `docs/prewarm-migration-strategy.md`.

## Why

The prewarm-detach upgrade strategy requires the VM's container to emit `ECLOUD_READY` / `ECLOUD_AWAITING_USERDATA` markers. Before the orchestrator attempts the prewarm path, it needs a cheap pre-check to confirm the baked-in container script supports those markers. This label is that signal — any image **without** it is definitionally pre-contract and gets routed through the standard (slower but safe) upgrade path.

## Changes

| File | Change |
|------|--------|
| `packages/sdk/src/client/common/templates/Dockerfile.layered.tmpl` | Added `LABEL eigenx_container_contract=v1` after existing labels |
| `packages/sdk/src/client/common/templates/dockerfileTemplate.test.ts` | New test asserts the label is present in rendered output |

## Companion PR

- **ecloud-platform:** Layr-Labs/ecloud-platform#124 — stamps the same label on platform-side layered images.

## Testing

```
 ✓ packages/sdk/src/client/common/templates/dockerfileTemplate.test.ts (3 tests)
   ✓ stamps eigenx_container_contract=v1 for prewarm-detach eligibility gate
```
