### PR TITLE
feat(sdk): show upgrade phase transitions during watchUntilUpgradeComplete

### DIFF
--- a/packages/sdk/src/client/common/contract/watcher.ts
+++ b/packages/sdk/src/client/common/contract/watcher.ts
@@ -126,10 +126,57 @@ export interface WatchUntilUpgradeCompleteOptions {
 
 const APP_STATUS_STOPPED = "Stopped";
 
+/** Human-friendly labels for upgrade phases */
+const UPGRADE_PHASE_LABELS: Record<string, string> = {
+  provisioning: "Provisioning new instance",
+  health_check: "Running health checks",
+  draining: "Switching traffic & draining old instance",
+  complete: "Complete",
+  rolling_back: "Rolling back",
+  rollback_done: "Rollback complete",
+  db_handoff: "Database handoff",
+  // Prewarm-detach phases
+  awaiting_userdata: "Waiting for instance readiness",
+  draining_old: "Draining old instance",
+  detached: "Detaching storage",
+  attached_to_new: "Attaching storage to new instance",
+  finalizing: "Finalizing new instance",
+  flipping: "Switching traffic",
+  teardown_old: "Cleaning up old instance",
+};
+
+/**
+ * Fetch the current upgrade phase for an app by querying the deployments endpoint.
+ * Returns the upgrade_phase of the most recent deployment, or undefined if unavailable.
+ */
+async function fetchUpgradePhase(
+  userApiClient: UserApiClient,
+  appId: Address,
+): Promise<string | undefined> {
+  try {
+    const deployments = await userApiClient.getDeployments(appId);
+    if (deployments.length === 0) return undefined;
+    // Deployments are returned newest-first (by created_at desc from the API)
+    // but if not, sort by createdAt descending
+    const sorted = [...deployments].sort((a, b) => {
+      const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return tb - ta;
+    });
+    return sorted[0].upgradePhase || undefined;
+  } catch {
+    // Best-effort: if the endpoint is unavailable, don't block the watcher
+    return undefined;
+  }
+}
+
 /**
  * Watch app until upgrade completes
  * For upgrades, we watch until the app reaches Stopped status (upgrade complete)
- * or Running status (if it was running before upgrade)
+ * or Running status (if it was running before upgrade).
+ *
+ * Provides real-time feedback by polling both the app status and the upgrade phase
+ * from the platform's deployment records.
  */
 export async function watchUntilUpgradeComplete(
   options: WatchUntilUpgradeCompleteOptions,
@@ -144,6 +191,11 @@ export async function watchUntilUpgradeComplete(
   let initialStatus: string | undefined;
   let initialIP: string | undefined;
   let hasChanged = false;
+
+  // Track upgrade phase and timing for progress feedback
+  const startTime = Date.now();
+  let lastLoggedStatus: string | undefined;
+  let lastLoggedPhase: string | undefined;
 
   // Stop condition: Watch for upgrade completion
   const stopCondition = (status: string, ip: string): boolean => {
@@ -195,25 +247,49 @@ export async function watchUntilUpgradeComplete(
   // Main watch loop
   while (true) {
     try {
-      // Fetch app info
-      const info = await userApiClient.getInfos([appId], 1);
-      if (info.length === 0) {
+      // Fetch app info and upgrade phase in parallel
+      const [infoResult, upgradePhase] = await Promise.all([
+        userApiClient.getInfos([appId], 1),
+        fetchUpgradePhase(userApiClient, appId),
+      ]);
+
+      if (infoResult.length === 0) {
         await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
         continue;
       }
 
-      const appInfo = info[0];
+      const appInfo = infoResult[0];
       const currentStatus = appInfo.status;
       const currentIP = appInfo.ip || "";
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+
+      // Log upgrade phase transitions
+      if (upgradePhase && upgradePhase !== lastLoggedPhase) {
+        const label = UPGRADE_PHASE_LABELS[upgradePhase] || upgradePhase;
+        logger.info(`Phase: ${label} (${elapsed}s)`);
+        lastLoggedPhase = upgradePhase;
+      }
+
+      // Log app status changes (only when phase info is unavailable, to avoid noise)
+      if (!upgradePhase && currentStatus !== lastLoggedStatus) {
+        logger.info(`Status: ${currentStatus} (${elapsed}s)`);
+        lastLoggedStatus = currentStatus;
+      }
 
       // Check stop condition
       if (stopCondition(currentStatus, currentIP)) {
+        const totalElapsed = Math.round((Date.now() - startTime) / 1000);
+        logger.info(`Upgrade completed in ${totalElapsed}s`);
         return;
       }
 
       // Wait before next poll
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     } catch (error: any) {
+      // Re-throw errors from stopCondition (e.g., app entered Failed state)
+      if (error.message?.includes("entered")) {
+        throw error;
+      }
       logger.warn(`Failed to fetch app info: ${error.message}`);
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     }

--- a/packages/sdk/src/client/common/utils/userapi.ts
+++ b/packages/sdk/src/client/common/utils/userapi.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import { Address, Hex, type PublicClient, type WalletClient } from "viem";
-import { calculatePermissionSignature } from "./auth";
+import { calculatePermissionSignature, calculateBillingAuthSignature } from "./auth";
 import { EnvironmentConfig } from "../types";
 import { stripHexPrefix } from "./helpers";
 import { requestWithRetry } from "./retry";
@@ -117,6 +117,17 @@ export interface AppResponse {
   creator?: string;
   contractStatus?: AppContractStatus;
   releases: AppRelease[];
+}
+
+export interface DeploymentInfo {
+  id: string;
+  externalId: string;
+  endpoint: string;
+  releaseId: string;
+  upgradePhase: string;
+  replacesDeploymentId: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 const MAX_ADDRESS_COUNT = 5;
@@ -304,6 +315,30 @@ export class UserApiClient {
     return apps.map((app: any, i: number) => ({
       address: (app.address || appIDs[i]) as Address,
       status: app.app_status || app.App_Status || "",
+    }));
+  }
+
+  /**
+   * Get deployments for an app from the gRPC-gateway endpoint.
+   * Returns deployment records including upgrade_phase for tracking upgrade progress.
+   *
+   * Endpoint: GET /v1/apps/:appAddress/deployments
+   */
+  async getDeployments(appAddress: Address): Promise<DeploymentInfo[]> {
+    const endpoint = `${this.config.userApiServerURL}/v1/apps/${appAddress}/deployments`;
+    const response = await this.makeEIP712AuthenticatedRequest(endpoint);
+    const result = await response.json();
+
+    const deployments = result.deployments || [];
+    return deployments.map((dep: any) => ({
+      id: dep.id || "",
+      externalId: dep.external_id || dep.externalId || "",
+      endpoint: dep.endpoint || "",
+      releaseId: dep.release_id || dep.releaseId || "",
+      upgradePhase: dep.upgrade_phase || dep.upgradePhase || "",
+      replacesDeploymentId: dep.replaces_deployment_id || dep.replacesDeploymentId || "",
+      createdAt: dep.created_at || dep.createdAt || "",
+      updatedAt: dep.updated_at || dep.updatedAt || "",
     }));
   }
 
@@ -504,6 +539,63 @@ export class UserApiClient {
       Authorization: `Bearer ${stripHexPrefix(signature)}`,
       "X-eigenx-expiry": expiry.toString(),
     };
+  }
+
+  /**
+   * Make an EIP-712 authenticated request to the gRPC-gateway endpoints.
+   * Uses the billing/compute auth pattern: Authorization + X-Account + X-Expiry headers.
+   */
+  private async makeEIP712AuthenticatedRequest(
+    url: string,
+  ): Promise<{ json: () => Promise<any>; text: () => Promise<string> }> {
+    const expiry = BigInt(Math.floor(Date.now() / 1000) + 5 * 60); // 5 minutes
+
+    const { signature } = await calculateBillingAuthSignature({
+      walletClient: this.walletClient,
+      product: "compute",
+      expiry,
+    });
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${signature}`,
+      "X-Account": this.address,
+      "X-Expiry": expiry.toString(),
+      "x-client-id": this.clientId,
+    };
+
+    try {
+      const response: AxiosResponse = await requestWithRetry({
+        method: "GET",
+        url,
+        headers,
+        maxRedirects: 0,
+        withCredentials: true,
+      });
+
+      const status = response.status;
+      if (status < 200 || status >= 300) {
+        const body =
+          typeof response.data === "string" ? response.data : JSON.stringify(response.data);
+        throw new Error(`gRPC-gateway request failed: ${status} - ${body}`);
+      }
+
+      return {
+        json: async () => response.data,
+        text: async () =>
+          typeof response.data === "string" ? response.data : JSON.stringify(response.data),
+      };
+    } catch (error: any) {
+      if (
+        error.message?.includes("fetch failed") ||
+        error.message?.includes("ECONNREFUSED") ||
+        error.message?.includes("ENOTFOUND") ||
+        error.cause
+      ) {
+        const cause = error.cause?.message || error.cause || error.message;
+        throw new Error(`Failed to connect to API at ${url}: ${cause}`);
+      }
+      throw error;
+    }
   }
 
   // ==========================================================================

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -124,6 +124,7 @@ export {
   type AppRelease,
   type AppReleaseBuild,
   type AppResponse,
+  type DeploymentInfo,
 } from "./common/utils/userapi";
 
 export { BillingApiClient } from "./common/utils/billingapi";


### PR DESCRIPTION
## Problem

When running `ecloud compute app upgrade`, the CLI shows "Waiting for upgrade to complete..." and then goes silent for 60-120 seconds until the upgrade either succeeds or fails. No intermediate feedback is provided.

## Solution

Poll the platform's existing `/v1/apps/:addr/deployments` gRPC-gateway endpoint in parallel with the `/info` status check to surface the `upgrade_phase` field with human-readable labels and elapsed time.

### Before
```
Waiting for upgrade to complete...
[... silence for 60-120s ...]
App is now running
```

### After
```
Waiting for upgrade to complete...
  Phase: Provisioning new instance (0s)
  Phase: Running health checks (38s)
  Phase: Switching traffic & draining old instance (47s)
  Phase: Complete (78s)
  App is now running
  Upgrade completed in 78s
```

## Changes

| File | What |
|------|------|
| `packages/sdk/src/client/common/contract/watcher.ts` | Add phase polling, elapsed-time logging, human-friendly phase labels, proper error re-throw for Failed state |
| `packages/sdk/src/client/common/utils/userapi.ts` | Add `getDeployments()` method using EIP-712 auth against the gRPC-gateway, add `DeploymentInfo` type, add `makeEIP712AuthenticatedRequest()` |
| `packages/sdk/src/client/index.ts` | Export `DeploymentInfo` type |

## Design Decisions

1. **Graceful degradation** — If the `/v1/apps/.../deployments` endpoint is unreachable (e.g., older platform version), `fetchUpgradePhase` catches errors silently and the watcher falls back to status-only logging.
2. **Parallel polling** — Both `getInfos` and `getDeployments` are called via `Promise.all` so no extra latency per poll cycle.
3. **No noise** — When phase info is available, status changes are suppressed to avoid duplicate messages.
4. **Bug fix** — The `Failed` state error is now properly re-thrown instead of being swallowed by the generic catch block.
5. **No backend changes needed** — The platform already exposes `upgrade_phase` on the Deployment proto via gRPC-gateway.

## Testing

- SDK `tsc --noEmit`: ✅ clean
- SDK tests (vitest): ✅ 32/32 pass
