### PR TITLE
fix(sdk): allow ECLOUD_PLATFORM_HOST override on layered image

### DIFF
--- a/packages/sdk/src/client/common/templates/Dockerfile.layered.tmpl
+++ b/packages/sdk/src/client/common/templates/Dockerfile.layered.tmpl
@@ -60,11 +60,27 @@ LABEL tee.launch_policy.monitoring_memory_allow={{resourceUsageAllow}}
 # any `tee-env-*` override at container-start with
 # "env var {...} is not allowed to be overridden on this image" and
 # exits with code 1 — which terminates the VM before the entrypoint
-# ever runs. ECLOUD_PD_EXPECTED is set on PD-backed apps so the
-# entrypoint (compute-source-env.sh) knows to wait for the persistent
-# disk before exec'ing the user workload. User-supplied env vars
-# flow through KMS (not tee-env-*) and don't need to be listed here.
-LABEL tee.launch_policy.allow_env_override=ECLOUD_PD_EXPECTED
+# ever runs. User-supplied env vars flow through KMS (not tee-env-*)
+# and don't need to be listed here.
+#
+# Entries:
+#   - ECLOUD_PD_EXPECTED   set on PD-backed apps so the entrypoint
+#                          (compute-source-env.sh) knows to wait for
+#                          the persistent disk before exec'ing the
+#                          user workload.
+#   - ECLOUD_PLATFORM_HOST the platform-routed hostname
+#                          (<addr>.<env>.eigencloud.xyz) so the
+#                          entrypoint's setup_tls can issue an ACME
+#                          cert for it. Injected by the CLI into
+#                          publicEnv at deploy/upgrade time and
+#                          propagated by ecloud-platform's
+#                          compute.go as a tee-env-* metadata key.
+#
+# The CS launcher parses this label as a comma-separated list
+# (go-tpm-tools/launcher/spec/launch_policy.go:185 — strings.Split
+# on ","). Quotes are not required; keep the value bare for
+# consistency with compute-tee's and eigenx-kms's existing labels.
+LABEL tee.launch_policy.allow_env_override=ECLOUD_PD_EXPECTED,ECLOUD_PLATFORM_HOST
 
 LABEL eigenx_cli_version={{ecloudCLIVersion}}
 LABEL eigenx_vm_image=eigen

--- a/packages/sdk/src/client/common/templates/dockerfileTemplate.test.ts
+++ b/packages/sdk/src/client/common/templates/dockerfileTemplate.test.ts
@@ -39,14 +39,24 @@ describe("Dockerfile.layered.tmpl", () => {
     ecloudCLIVersion: "0.0.0-test",
   };
 
-  it("emits the tee.launch_policy.allow_env_override label for ECLOUD_PD_EXPECTED", () => {
-    // Regression guard for the 2026-05-04 dev incident where the
-    // Confidential Space launcher rejected the orchestrator's
-    // `tee-env-ECLOUD_PD_EXPECTED=1` override because this label
-    // wasn't set, exiting the VM before the entrypoint ran. Without
-    // this label, PD-backed apps can never deploy.
+  it("allow-lists every tee-env-* var ecloud-platform sets on the VM", () => {
+    // Regression guard for the same class of CS-launcher
+    // env-override rejections that first hit us on 2026-05-04
+    // (ECLOUD_PD_EXPECTED) and again on 2026-05-13 with
+    // ECLOUD_PLATFORM_HOST. The launcher refuses to start the
+    // container when compute.go emits a tee-env-* whose key isn't
+    // in this label's comma-separated list. Missing a name here
+    // means every fresh deploy silently fails with the VM booting,
+    // the container refusing to start, and the platform incorrectly
+    // reporting 'Running' because the readiness check is skipped
+    // for imported builds.
     const rendered = render(base);
-    expect(rendered).toContain("LABEL tee.launch_policy.allow_env_override=ECLOUD_PD_EXPECTED");
+    expect(rendered).toMatch(
+      /LABEL tee\.launch_policy\.allow_env_override=([A-Z_,]*\b)ECLOUD_PD_EXPECTED\b/,
+    );
+    expect(rendered).toMatch(
+      /LABEL tee\.launch_policy\.allow_env_override=([A-Z_,]*\b)ECLOUD_PLATFORM_HOST\b/,
+    );
   });
 
   it("tags the image with eigenx_vm_image=eigen (needed for platform's image-family selection)", () => {


### PR DESCRIPTION
## Summary

Fixes a silent deploy failure introduced by the cert-routing PR (#149, shipped as 1.0.0-devep3). Every fresh deploy produced by that CLI was failing to serve traffic: the container refused to start, Caddy never came up, and nginx proxied to a dead upstream — but the platform incorrectly reported the app as \`Running\` because the readiness check is skipped for imported builds.

## Root cause

#149 adds \`ECLOUD_PLATFORM_HOST\` to the release's \`publicEnv\` so the VM entrypoint's \`setup_tls\` knows which hostname to request a cert for. On the platform side, \`compute.go\` loops over \`spec.Env\` and emits every entry as a \`tee-env-<name>\` GCE metadata key:

\`\`\`go
// pkg/services/infraService/providers/gcp/compute.go:326
for _, env := range spec.Env {
    metadata = append(metadata, &computepb.Items{
        Key:   proto.String(fmt.Sprintf(\"tee-env-%s\", env.Name)),
        Value: proto.String(env.Value),
    })
}
\`\`\`

The Confidential Space launcher refuses to start a container when it sees a \`tee-env-*\` whose base name isn't in the image's \`tee.launch_policy.allow_env_override\` label, logging:

\`\`\`
ERROR msg=\"env var {ECLOUD_PLATFORM_HOST <addr>.testnet-sepolia.eigencloud.xyz} is
not allowed to be overridden on this image; allowed envs to be overridden:
[ECLOUD_PD_EXPECTED]\"
\`\`\`

The Dockerfile.layered.tmpl's label only listed \`ECLOUD_PD_EXPECTED\`.

## Evidence from sepolia-dev

I reproduced this today (2026-05-13) by running my scripts/e2e harness against sepolia-dev with CLI 1.0.0-devep3. The on-chain deploy completed, the VM booted, but:

- \`curl https://<addr>.testnet-sepolia.eigencloud.xyz/health\` — TLS handshake timed out (nginx connected but upstream didn't ALPN)
- \`gcloud compute instances get-serial-port-output <vm>\` — only kernel + launcher lines, no \`compute-source-env.sh\` output (entrypoint never executed)
- \`ecloud compute app logs <addr>\` — contained the smoking-gun error quoted above

## Fix

Single-line change in \`Dockerfile.layered.tmpl\`:

\`\`\`diff
-LABEL tee.launch_policy.allow_env_override=ECLOUD_PD_EXPECTED
+LABEL tee.launch_policy.allow_env_override=ECLOUD_PD_EXPECTED,ECLOUD_PLATFORM_HOST
\`\`\`

Plus a comment block explaining each entry and the CS launcher's parse format (\`strings.Split(v, \",\")\`, per \`go-tpm-tools/launcher/spec/launch_policy.go:185\`).

\`dockerfileTemplate.test.ts\` was previously asserting a substring match that would have passed silently if only one of the two names made it into the label. Tightened the regressions guard to two independent regex matches — \`ECLOUD_PD_EXPECTED\\b\` and \`ECLOUD_PLATFORM_HOST\\b\` — so a future single-name regression can't hide.

## Why the readiness check didn't catch this upstream

This is the bug that made a container-never-started failure look like a clean deploy:

- \`pkg/services/infraService/providers/gcp/provider.go:294\` skips \`waitForStartupReady\` when \`BuildType.IsImported() && ContractVersion != \"v1\"\`.
- CLI-deployed apps go through the legacy \`/release\` path, which sets buildType=imported but doesn't stamp a ContractVersion (see \`pkg/services/buildService/helpers.go:160\`'s NOTE: \"imported images do not flow through SubmitBuild, so they never receive a ContractVersion stamp in the DB\").
- So the orchestrator returns success the moment the VM is created, never polls for ECLOUD_READY, and proceeds to AddRoute on a VM whose container hasn't even started.

Closing that gap is a separate PR in ecloud-platform — not in this CLI fix — but worth calling out so the reviewer knows this one-liner is the right surgical fix for the symptom, not a workaround.

## Test plan

- [x] \`pnpm vitest run\` on the SDK — 35 pass (including the updated allow-list test).
- [ ] Publish 1.0.0-devep4 once merged.
- [ ] Re-run \`scripts/e2e/scenarios/02_platform_deploy_then_platform_upgrade.sh\` against sepolia-dev with the new CLI, confirm the full deploy→upgrade path reaches verify and passes the downtime SLO.