### PR TITLE
fix(sdk): drop broken DNS precheck from setup_tls

### DIFF
--- a/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
+++ b/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
@@ -61,45 +61,6 @@ else
     exit 1
 fi
 
-# dns_points_here returns 0 if $1 resolves (A record) to our external
-# IPv4. Used to gate ACME on DNS being wired before we start burning
-# Let's Encrypt's 5-cert-per-domain-per-week rate limit. Returns 1 on
-# any failure (tool missing, lookup error, mismatch) so callers treat
-# "I can't tell" the same as "not ready yet".
-dns_points_here() {
-    local host="$1"
-    local external_ip
-    # GCE metadata is always reachable from a VM on GCE. The
-    # alternative (dig OPT CHAOS to an upstream) adds a dependency;
-    # the metadata server is already a hard prereq for KMS auth above.
-    external_ip="$(curl -fsS -H 'Metadata-Flavor: Google' \
-        'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip' 2>/dev/null || true)"
-    if [ -z "$external_ip" ]; then
-        echo "compute-source-env.sh: DNS precheck for $host skipped: no external IP from metadata"
-        return 1
-    fi
-    local resolved
-    if command -v getent >/dev/null 2>&1; then
-        resolved="$(getent ahostsv4 "$host" 2>/dev/null | awk 'NR==1{print $1}')"
-    elif command -v host >/dev/null 2>&1; then
-        resolved="$(host -t A "$host" 2>/dev/null | awk '/has address/{print $4; exit}')"
-    elif command -v dig >/dev/null 2>&1; then
-        resolved="$(dig +short A "$host" 2>/dev/null | awk 'NR==1{print}')"
-    else
-        echo "compute-source-env.sh: DNS precheck for $host skipped: no resolver tool available"
-        return 1
-    fi
-    if [ -z "$resolved" ]; then
-        echo "compute-source-env.sh: DNS precheck: $host has no A record yet"
-        return 1
-    fi
-    if [ "$resolved" != "$external_ip" ]; then
-        echo "compute-source-env.sh: DNS precheck: $host resolves to $resolved but this VM is $external_ip"
-        return 1
-    fi
-    return 0
-}
-
 # issue_cert_for runs tls-keygen for a single hostname and copies the
 # produced fullchain/privkey into $1's output directory ($2). Returns
 # 0 on success, non-zero on any failure (caller decides whether that's
@@ -131,9 +92,16 @@ issue_cert_for() {
 #   - ECLOUD_PLATFORM_HOST (platform-routed <addr>.<env>.eigencloud.xyz),
 #     when the CLI/platform has set it
 #   - DOMAIN (user-supplied custom domain), when set and non-localhost
-# Both hostnames are gated on DNS already pointing at this VM so we
-# don't burn Let's Encrypt rate limits on apps whose routing isn't
-# wired up yet (prewarm/migration window).
+#
+# No client-side DNS precheck. Earlier versions tried to gate ACME on
+# "does this hostname resolve to my external IP" but that's wrong for
+# the platform-routing model (DNS points at the shared nginx NLB, not
+# the VM) and was preventing cert issuance on the production path.
+# tls-client (eigencompute-containers/tls-client) does its own DNS
+# poll before calling ACME and surfaces a clear error when challenges
+# can't reach the VM, which is the right place for that check —
+# attempting it here from inside the VM cannot tell platform-routed
+# from compute-tee-routed apps.
 setup_tls() {
     # If tls-keygen isn't present, TLS wasn't configured during build
     if [ ! -x /usr/local/bin/tls-keygen ]; then
@@ -192,30 +160,22 @@ setup_tls() {
     local certs_issued=0
 
     if [ -n "$platform_host" ]; then
-        if dns_points_here "$platform_host"; then
-            if issue_cert_for "$platform_host" "/run/tls/platform" "$mnemonic" "$challenge" "$staging_flag"; then
-                certs_issued=$((certs_issued + 1))
-            else
-                echo "compute-source-env.sh: ERROR - failed to issue cert for platform host $platform_host"
-                echo "ECLOUD_FAIL tls_setup"
-                exit 1
-            fi
+        if issue_cert_for "$platform_host" "/run/tls/platform" "$mnemonic" "$challenge" "$staging_flag"; then
+            certs_issued=$((certs_issued + 1))
         else
-            echo "compute-source-env.sh: skipping platform cert for $platform_host — DNS not pointing here yet"
+            echo "compute-source-env.sh: ERROR - failed to issue cert for platform host $platform_host"
+            echo "ECLOUD_FAIL tls_setup"
+            exit 1
         fi
     fi
 
     if [ -n "$user_domain" ]; then
-        if dns_points_here "$user_domain"; then
-            if issue_cert_for "$user_domain" "/run/tls/domain" "$mnemonic" "$challenge" "$staging_flag"; then
-                certs_issued=$((certs_issued + 1))
-            else
-                echo "compute-source-env.sh: ERROR - failed to issue cert for user domain $user_domain"
-                echo "ECLOUD_FAIL tls_setup"
-                exit 1
-            fi
+        if issue_cert_for "$user_domain" "/run/tls/domain" "$mnemonic" "$challenge" "$staging_flag"; then
+            certs_issued=$((certs_issued + 1))
         else
-            echo "compute-source-env.sh: skipping user-domain cert for $user_domain — DNS not pointing here yet"
+            echo "compute-source-env.sh: ERROR - failed to issue cert for user domain $user_domain"
+            echo "ECLOUD_FAIL tls_setup"
+            exit 1
         fi
     fi
 


### PR DESCRIPTION
## Summary

The \`dns_points_here\` helper added by [#149](https://github.com/Layr-Labs/ecloud/pull/149) compared each hostname's resolved A record to the VM's GCE external IP and skipped cert issuance on a mismatch. That works for compute-tee's static-IP routing model where DNS points directly at the VM, but is **wrong for ecloud-platform's nginx-fronted routing model** where DNS for \`<addr>.<env>.eigencloud.xyz\` points at the shared NLB (\`34.73.90.95\` on dev), not at any individual VM.

## Repro from sepolia-dev (2026-05-13)

After landing the env-allow-list fix (#150) and the readiness-wait fix (Layr-Labs/ecloud-platform#153), I bumped the e2e harness to CLI \`1.0.0-devep5\` and re-ran scenario 02. The orchestrator now correctly waits for \`ECLOUD_READY\` (~2 min) and reports \`Running\`, but \`fetch_app_state\` still fails because TLS handshake from the public hostname times out. Pulled \`ecloud compute app logs\`:

\`\`\`
compute-source-env.sh: Successfully fetched environment variables from KMS
compute-source-env.sh: DNS precheck: <addr>.testnet-sepolia.eigencloud.xyz resolves to
                      34.73.90.95 but this VM is 34.134.189.206
compute-source-env.sh: skipping platform cert for <addr>.testnet-sepolia.eigencloud.xyz —
                      DNS not pointing here yet
compute-source-env.sh: no certs issued, skipping Caddy (app will serve plaintext until DNS is wired)
ECLOUD_READY runtime_bootstrapped
\`\`\`

\`34.73.90.95\` is the platform's nginx NLB. Traffic flow is **NLB → nginx → VM:443**, so DNS pointing at the NLB is correct routing — but my precheck reads it as \"DNS isn't wired\" and bails.

## Fix

Drop the \`dns_points_here\` helper entirely. Let \`issue_cert_for\` run unconditionally; the underlying \`tls-client\` (from \`eigencompute-containers/tls-client\`) already:

- Does its own DNS poll with exponential backoff before calling ACME (\`lego_manager.go:131-143\`).
- Surfaces a clear ACME error when challenges can't reach the VM.

So the right place for this check is inside \`tls-client\`, not the entrypoint. Anything we add at the entrypoint level cannot tell platform-routed from compute-tee-routed apps and produces a strict-superset of false negatives.

ACME failures still become \`ECLOUD_FAIL tls_setup\` and the orchestrator's readiness wait (also new) surfaces them with the serial tail captured in \`ReadinessError\`.

## Diff

\`\`\`
1 file changed, 20 insertions(+), 60 deletions(-)
\`\`\`

The full \`dns_points_here\` function and both call sites (\`platform_host\` and \`user_domain\` branches) are gone. Nothing else changed.

## Test plan

- [x] \`pnpm vitest run\` on SDK — 35/35 pass.
- [ ] After publish (\`1.0.0-devep6\`): re-run \`scripts/e2e/scenarios/02_platform_deploy_then_platform_upgrade.sh\` against sepolia-dev. Expect:
  - VM boots
  - \`tls-client\` issues a cert for the platform host (because DNS is wired and nginx forwards :80 challenges to VM:80 via the proxy_route the orchestrator added)
  - Caddy starts, listens on :443
  - \`https://<addr>.testnet-sepolia.eigencloud.xyz/health\` returns 200
  - Probe records the upgrade window, verify_downtime passes