### PR TITLE
fix(ci): add version comments to SHA-pinned GitHub Actions

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -41,10 +41,10 @@ jobs:
           echo "Building dev version: $PACKAGE_VERSION"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -48,10 +48,10 @@ jobs:
           echo "Building production version: $PACKAGE_VERSION"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary

- All three GitHub Actions in both workflow files were already correctly SHA-pinned
- `pnpm/action-setup` and `actions/setup-node` were missing the version comment that makes pinned SHAs human-readable and auditable
- No SHA values were changed — only version comments added

## SHA Verification

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` | v4.2.2 (already commented) |
| `pnpm/action-setup` | `fc06bc1257f339d1d5d8b3a19a8cae5388b55320` | v4.4.0 (comment added) |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 (comment added) |

All SHAs verified via GitHub API against their respective release tags.

## Test plan

- [ ] Verify the SHAs in the diff still match the tagged versions on GitHub
- [ ] Confirm CI workflows continue to pass after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)