### PR TITLE
fix(sdk): reject TEE runtime's boot-disk premount of /mnt/disks/userdata

### DIFF
--- a/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
+++ b/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
@@ -255,13 +255,89 @@ export KMS_PUBLIC_KEY="$(cat /usr/local/bin/kms-signing-public-key.pem)"
 USERDATA_MOUNT="/mnt/disks/userdata"
 USERDATA_DEV="/dev/disk/by-id/google-persistent_storage_1"
 
+# userdata_mount_backing_dev resolves the kernel device that currently
+# backs $USERDATA_MOUNT (or empty string if not mounted). The output is
+# canonicalized via readlink so we can compare against $USERDATA_DEV
+# without caring whether the mount table records the symlinked
+# /dev/disk/by-id/... path or the underlying /dev/sdb-style path.
+#
+# Tries findmnt first (clean structured output), falls back to parsing
+# /proc/self/mountinfo so we don't add a hard dependency on util-linux
+# being present in the image.
+userdata_mount_backing_dev() {
+    if command -v findmnt >/dev/null 2>&1; then
+        local src
+        src=$(findmnt -n -o SOURCE -- "$USERDATA_MOUNT" 2>/dev/null) || return 0
+        [ -n "$src" ] || return 0
+        readlink -f "$src" 2>/dev/null || echo "$src"
+        return 0
+    fi
+    # /proc/self/mountinfo line shape (kernel docs): mount-id parent-id
+    # major:minor root mount-point ... So column 5 is the mount point and
+    # the device path lives in the optional fields after the "-" separator.
+    # We just need the major:minor → device mapping; awk + a /sys lookup
+    # is cleaner than parsing the mountinfo's optional-field section.
+    local maj_min dev_basename
+    maj_min=$(awk -v mp="$USERDATA_MOUNT" '$5 == mp { print $3 }' /proc/self/mountinfo 2>/dev/null | head -1)
+    [ -n "$maj_min" ] || return 0
+    dev_basename=$(readlink "/sys/dev/block/${maj_min}" 2>/dev/null | awk -F/ '{print $NF}')
+    [ -n "$dev_basename" ] || return 0
+    readlink -f "/dev/${dev_basename}" 2>/dev/null || echo "/dev/${dev_basename}"
+}
+
+# expected_userdata_dev resolves $USERDATA_DEV through any symlinks so
+# string-compare against userdata_mount_backing_dev is meaningful even
+# when the kernel hands us a /dev/nvme0n1-style path while
+# /dev/disk/by-id/google-persistent_storage_1 is the symlink GCE
+# publishes.
+expected_userdata_dev() {
+    if [ -e "$USERDATA_DEV" ]; then
+        readlink -f "$USERDATA_DEV" 2>/dev/null || echo "$USERDATA_DEV"
+    else
+        echo "$USERDATA_DEV"
+    fi
+}
+
 wait_for_userdata() {
     if [ "${ECLOUD_PD_EXPECTED:-0}" != "1" ]; then
         return 0
     fi
     if mountpoint -q "$USERDATA_MOUNT" 2>/dev/null; then
-        echo "compute-source-env.sh: userdata already mounted at $USERDATA_MOUNT"
-        return 0
+        # The mount slot is taken — but is it taken by the PD we're
+        # about to attach, or by something else? The Confidential Space
+        # TEE runtime's SetupSecondaryEncryptedVolume step probes for a
+        # secondary GCE disk once at boot, doesn't see it (because the
+        # orchestrator hasn't called AttachPD yet — the contract says
+        # the new VM signals awaiting-userdata FIRST), and falls back
+        # to mounting an encrypted folder on the BOOT disk at this same
+        # path. If we accept that mount as-is, the user app boots on a
+        # fresh empty filesystem and the orchestrator's late AttachPD
+        # silently lands on a VM that's already serving from boot disk.
+        # See docs/solutions/2026-05-15-prewarm-detach-pd-preservation-boot-race.md
+        # in ecloud-platform.
+        local backing expected
+        backing=$(userdata_mount_backing_dev)
+        expected=$(expected_userdata_dev)
+        if [ -n "$backing" ] && [ "$backing" = "$expected" ]; then
+            echo "compute-source-env.sh: userdata already mounted at $USERDATA_MOUNT (backed by $backing)"
+            return 0
+        fi
+        # Mount slot taken, but NOT by our PD. This is the runtime
+        # premount on boot disk. Try to recover by lazy-unmounting (the
+        # filesystem is fresh and unused — no app has written to it
+        # yet), then fall through to the normal wait-for-PD loop.
+        echo "compute-source-env.sh: WARNING - $USERDATA_MOUNT premounted by TEE runtime fallback (backing=${backing:-unknown}, expected=$expected); attempting recovery"
+        if ! umount -l "$USERDATA_MOUNT" 2>/dev/null; then
+            # Lazy unmount should never fail under normal circumstances —
+            # it doesn't wait for open files, just detaches the namespace.
+            # If it did fail, we have no path forward: the orchestrator's
+            # strict-mode WaitAwaitingUserdata gate (ecloud-platform PR
+            # #174) catches our ECLOUD_FAIL within one poll tick and
+            # rolls back, leaving the user's data safe on the old VM.
+            echo "ECLOUD_FAIL pd_runtime_premount_unrecoverable"
+            exit 1
+        fi
+        echo "compute-source-env.sh: unmounted runtime fallback at $USERDATA_MOUNT, waiting for real PD"
     fi
     # Refuse to proceed if the tools we need for safe first-attach
     # detection are missing. Without blkid we cannot tell an empty new

--- a/packages/sdk/src/client/common/templates/scriptTemplate.test.ts
+++ b/packages/sdk/src/client/common/templates/scriptTemplate.test.ts
@@ -94,4 +94,35 @@ describe("compute-source-env.sh.tmpl", () => {
     expect(rendered).not.toMatch(/caddy validate[^\n]*2>\/dev\/null/);
     expect(rendered).toMatch(/caddy validate --config \/etc\/caddy\/Caddyfile --adapter caddyfile;/);
   });
+
+  it("rejects /mnt/disks/userdata premounted by the TEE runtime fallback on boot disk", () => {
+    // The Confidential Space TEE runtime's SetupSecondaryEncryptedVolume
+    // step probes for a secondary GCE disk once at boot, doesn't see one
+    // (because the orchestrator's AttachPD hasn't run yet — the contract
+    // says the new VM signals awaiting-userdata FIRST), and falls back to
+    // mounting an encrypted folder on the BOOT DISK at /mnt/disks/userdata.
+    // The previous wait_for_userdata implementation accepted that mount
+    // as-is — short-circuiting the wait-for-PD loop and letting the user
+    // app start on a fresh empty filesystem, while the orchestrator's
+    // late AttachPD landed on a VM that was already serving from boot
+    // disk. Result: silent data loss on every prewarm-detach upgrade
+    // that lost the boot-vs-attach race. Diagnosis lives in
+    // ecloud-platform docs/solutions/2026-05-15-prewarm-detach-pd-preservation-boot-race.md.
+    const rendered = render(data);
+    // The mount-slot check now compares the backing device against the
+    // expected $USERDATA_DEV.
+    expect(rendered).toContain("userdata_mount_backing_dev");
+    expect(rendered).toContain("expected_userdata_dev");
+    // On detect, lazy-unmount the runtime fallback and fall through to
+    // the wait loop.
+    expect(rendered).toMatch(/umount -l "\$USERDATA_MOUNT"/);
+    // If unmount itself fails, fail-fast so the orchestrator's strict
+    // WaitAwaitingUserdata gate (ecloud-platform PR #174) catches it
+    // within one poll tick rather than letting the wait time out.
+    expect(rendered).toContain("ECLOUD_FAIL pd_runtime_premount_unrecoverable");
+    // Both findmnt and a /proc/self/mountinfo fallback are present, so
+    // the fix doesn't add a hard dependency on util-linux.
+    expect(rendered).toContain("findmnt");
+    expect(rendered).toContain("/proc/self/mountinfo");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the underlying TEE-runtime side of the prewarm-detach PD-preservation bug diagnosed in ecloud-platform's [`docs/solutions/2026-05-15-prewarm-detach-pd-preservation-boot-race.md`](https://github.com/Layr-Labs/ecloud-platform/pull/174/files#diff-fa84b4c3e95f8e0a6c7e3e8e7d35f3a5bb00ac5c5e0a8e0c8e0c8e0c8e0c8e0c). Reproduced 1/1 on dev; documented end-to-end timeline lives in that doc.

The Confidential Space TEE runtime's `SetupSecondaryEncryptedVolume` step probes for a secondary GCE disk **once** at boot. On the prewarm-detach upgrade flow, the new VM is provisioned WITHOUT the data disk (the orchestrator attaches it later, after observing `ECLOUD_AWAITING_USERDATA`). The probe sees no secondary disk and **falls back to mounting an encrypted folder on the BOOT disk at `/mnt/disks/userdata`**. The previous `wait_for_userdata` accepted that mount as-is — short-circuiting the wait-for-PD loop and letting the user app start on a fresh empty filesystem. The orchestrator's late `AttachPD` then landed on a VM that was already serving from boot disk, and the user's data on the actual PD was silently orphaned.

## What this PR changes

In `packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl`:

1. **`userdata_mount_backing_dev()`** — new helper that resolves the kernel device currently backing `$USERDATA_MOUNT`. Tries `findmnt` for clean structured output, falls back to parsing `/proc/self/mountinfo` + a `/sys/dev/block` major:minor lookup so we don't add a hard `util-linux` dependency to user images.
2. **`expected_userdata_dev()`** — resolves `$USERDATA_DEV` through any symlinks so the string compare against (1) is meaningful even when the kernel hands us a `/dev/nvme0n1`-style path while `/dev/disk/by-id/google-persistent_storage_1` is the symlink GCE publishes.
3. **`wait_for_userdata()`** — when `mountpoint -q` succeeds, check whether the backing device matches `$USERDATA_DEV`:
   - **Match** → keep the existing fast-path (PD already attached, we're good).
   - **Mismatch** (the runtime fallback on boot disk) → lazy-unmount it and fall through to the existing wait-for-PD loop. That loop emits `ECLOUD_AWAITING_USERDATA`, the orchestrator proceeds with `AttachPD`, and recovery succeeds end to end.
   - **Lazy-unmount itself fails** → emit `ECLOUD_FAIL pd_runtime_premount_unrecoverable`. The orchestrator's strict-mode `WaitAwaitingUserdata` gate (Layr-Labs/ecloud-platform#174) catches this within one poll tick and rolls back, leaving the user's data safe on the old VM.

## Why "recover, don't fail-fast"

ecloud-platform PR #174 already converts the silent data-loss bug into a loud upgrade failure. That's the safety net. This PR's value is that it **avoids** the upgrade failure entirely on the common case — the runtime's boot-disk fallback is a fresh empty filesystem with no app writes yet, so unmounting it and waiting for the real PD is safe and recoverable.

## Test plan

- [x] `pnpm exec vitest run packages/sdk/src/client/common/templates/scriptTemplate.test.ts` — 7/7 pass (1 new subtest)
- [x] `pnpm exec vitest run --dir packages/sdk` — 38/38 pass
- [x] `bash -n compute-source-env.sh.tmpl` — clean
- [x] `pnpm exec prettier --check` on touched files — clean
- [ ] Build a new platform CLI from this branch and run ecloud-platform's `scripts/e2e/loop.sh 5 scenarios/02_*.sh` against sepolia-dev. Expectation: no FAILs (where without this fix and without #174 the FAIL is silent data loss; with #174 alone the FAIL is loud rollback; with this PR the failure mode disappears for the common runtime-premount case).

## Related

- ecloud-platform PR #174 — orchestrator-side strict gate (the safety net this PR's fast-fail relies on)
- ecloud-platform `docs/solutions/2026-05-15-prewarm-detach-pd-preservation-boot-race.md` — full diagnosis