### PR TITLE
refactor(sdk): defer PD lifecycle from script to launcher

### DIFF
--- a/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
+++ b/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
@@ -10,24 +10,25 @@
 #   /usr/local/bin/kms-signing-public-key.pem at layer-build time by the CLI.
 #
 # ecloud-platform divergence from compute-tee:
-#   This script emits ECLOUD_READY / ECLOUD_FAIL / ECLOUD_AWAITING_USERDATA /
-#   ECLOUD_DETACHED markers to stdout at key lifecycle points. The GCP
-#   provisioner's serial-console watcher in ecloud-platform
-#   (pkg/services/infraService/providers/gcp/compute.go) parses those
-#   markers to gate "VM ready" and to coordinate the prewarm-detach
-#   upgrade flow. Without the markers, the platform's waitForStartupReady
-#   times out at ~10 minutes per deploy, rollback fires, and the VM is
-#   deleted — seen in dev on 2026-05-04 with an older copy of this
-#   template that lacked the markers.
+#   This script emits ECLOUD_READY / ECLOUD_FAIL markers to stdout at key
+#   lifecycle points. The GCP provisioner's serial-console watcher in
+#   ecloud-platform (pkg/services/infraService/providers/gcp/compute.go)
+#   parses those markers to gate "VM ready". Without the markers, the
+#   platform's waitForStartupReady times out at ~10 minutes per deploy,
+#   rollback fires, and the VM is deleted — seen in dev on 2026-05-04
+#   with an older copy of this template that lacked the markers.
 #
-#   Prewarm-detach contract:
-#     - If ECLOUD_PD_EXPECTED=1 and /mnt/disks/userdata is not present at boot,
-#       emit ECLOUD_AWAITING_USERDATA and wait until the disk is attached.
-#     - On SIGTERM (drain-requested), forward to child, wait for exit, sync
-#       + unmount /mnt/disks/userdata, emit ECLOUD_DETACHED, exit.
-#     - ECLOUD_READY is emitted once runtime is bootstrapped (same as before).
-#     - ECLOUD_FAIL is emitted on any unrecoverable setup error.
-#   Keep the markers on any line that resolves a lifecycle outcome.
+#   Prewarm-detach (PD-backed apps):
+#     The PD lifecycle markers ECLOUD_AWAITING_USERDATA and ECLOUD_DETACHED
+#     are emitted by the cos-tdx LAUNCHER (Layr-Labs/go-tpm-tools), not this
+#     script. When the launcher is configured with tee-await-late-attach=true,
+#     it emits ECLOUD_AWAITING_USERDATA on serial, waits for the orchestrator's
+#     AttachPD, completes LUKS+mount, AND ONLY THEN starts this user container.
+#     On user-container exit the launcher unmounts and emits ECLOUD_DETACHED.
+#     The script's job for PD apps is just to forward SIGTERM to the user app
+#     (graceful drain) — LUKS, mount, and unmount are not the script's
+#     concern, and the user container does not have CAP_SYS_ADMIN to do them
+#     anyway.
 #
 #   This file is kept in lockstep with
 #   ecloud-platform/pkg/services/buildService/assets/compute-source-env.sh.tmpl
@@ -248,96 +249,27 @@ setup_tls
 export KMS_SERVER_URL="{{kmsServerURL}}"
 export KMS_PUBLIC_KEY="$(cat /usr/local/bin/kms-signing-public-key.pem)"
 
-# ── Prewarm-detach: wait for PD if expected ──
-# Orchestrator sets ECLOUD_PD_EXPECTED=1 on apps using StorageBackend=pd.
-# When the prewarm path is used, the new VM boots WITHOUT the disk; we
-# signal awaiting-userdata and poll until the disk is attached.
-USERDATA_MOUNT="/mnt/disks/userdata"
-USERDATA_DEV="/dev/disk/by-id/google-persistent_storage_1"
+# ── Prewarm-detach note ──
+# The PD lifecycle (mount, LUKS, unmount, detach) is owned by the cos-tdx
+# launcher, not this script. When the launcher is configured with
+# tee-await-late-attach=true, it emits ECLOUD_AWAITING_USERDATA on serial,
+# waits for the orchestrator's AttachPD, completes LUKS+mount, AND ONLY THEN
+# starts this user container. The bind-mount source at /mnt/disks/userdata
+# is already populated by the time we run. On user-container exit the
+# launcher unmounts and emits ECLOUD_DETACHED. The user container does not
+# have CAP_SYS_ADMIN, so umount and cryptsetup would fail with EPERM here
+# anyway — moving the work to the launcher (which runs with full caps) is
+# the only place it can actually succeed.
 
-wait_for_userdata() {
-    if [ "${ECLOUD_PD_EXPECTED:-0}" != "1" ]; then
-        return 0
-    fi
-    if mountpoint -q "$USERDATA_MOUNT" 2>/dev/null; then
-        echo "compute-source-env.sh: userdata already mounted at $USERDATA_MOUNT"
-        return 0
-    fi
-    # Refuse to proceed if the tools we need for safe first-attach
-    # detection are missing. Without blkid we cannot tell an empty new
-    # disk from an already-formatted one — running mkfs.ext4 on the
-    # latter would destroy data.
-    if ! command -v blkid >/dev/null 2>&1; then
-        echo "ECLOUD_FAIL pd_tools_missing"
-        exit 1
-    fi
-    echo "ECLOUD_AWAITING_USERDATA"
-    echo "compute-source-env.sh: waiting for PD at $USERDATA_DEV..."
-    # Poll for up to 10 minutes (120 * 5s). The orchestrator's overall
-    # attach timeout is shorter; the ceiling here just bounds the wait
-    # for manual / diagnostic scenarios.
-    local i=0
-    local mount_failures=0
-    while [ "$i" -lt 120 ]; do
-        if [ -e "$USERDATA_DEV" ]; then
-            mkdir -p "$USERDATA_MOUNT"
-            if mount -o noatime "$USERDATA_DEV" "$USERDATA_MOUNT" 2>/dev/null; then
-                echo "compute-source-env.sh: PD mounted at $USERDATA_MOUNT"
-                return 0
-            fi
-            # Disk present but mount failed. Check whether it has a
-            # recognized filesystem. `blkid -s TYPE -o value` prints the
-            # FS type (empty if none). We only mkfs when there is
-            # demonstrably NO filesystem — never on the basis of blkid
-            # returning non-zero alone, which could mean "blkid missing"
-            # or "device busy".
-            local fstype
-            fstype=$(blkid -s TYPE -o value "$USERDATA_DEV" 2>/dev/null)
-            if [ -z "$fstype" ]; then
-                echo "compute-source-env.sh: formatting $USERDATA_DEV (first attach)"
-                mkfs.ext4 -F -L eclouddata "$USERDATA_DEV" >/dev/null 2>&1 || {
-                    echo "ECLOUD_FAIL pd_mkfs_failed"
-                    exit 1
-                }
-                mount -o noatime "$USERDATA_DEV" "$USERDATA_MOUNT" || {
-                    echo "ECLOUD_FAIL pd_mount_after_format_failed"
-                    exit 1
-                }
-                return 0
-            fi
-            # Disk has a filesystem but mount still failed. Give it a
-            # few retries to cover transient cases (device busy, udev
-            # still settling), but don't pretend this is an attach
-            # timeout if it persists.
-            mount_failures=$((mount_failures + 1))
-            if [ "$mount_failures" -ge 6 ]; then
-                echo "ECLOUD_FAIL pd_mount_failed"
-                exit 1
-            fi
-        else
-            # Device disappeared (e.g. udev re-enumeration between
-            # attach and mount). Reset the consecutive-failure counter
-            # so only true back-to-back mount failures trip
-            # pd_mount_failed; a device blip should not steal retries.
-            mount_failures=0
-        fi
-        i=$((i + 1))
-        sleep 5
-    done
-    echo "ECLOUD_FAIL pd_attach_timeout"
-    exit 1
-}
-
-wait_for_userdata
-
-# ── Prewarm-detach: install SIGTERM handler for graceful drain ──
+# ── Drain SIGTERM handler ──
 # Orchestrator signals drain by setting the instance metadata key
-# ECLOUD_DRAIN_REQUESTED=1, which a host-level agent translates into
+# ECLOUD_DRAIN_REQUESTED=1, which a host-level watcher translates into
 # SIGTERM on PID 1. On SIGTERM we:
 #   1. Forward to the child (wakes the user's app for graceful exit)
 #   2. Wait for child exit
-#   3. Sync + unmount the PD
-#   4. Emit ECLOUD_DETACHED so the orchestrator can proceed to detach
+# The launcher then runs its post-container cleanup (umount + cryptsetup
+# close + ECLOUD_DETACHED emit) once this script's exit unblocks
+# launcher.Run(); the script doesn't unmount or emit ECLOUD_DETACHED itself.
 CHILD_PID=""
 _DRAIN_IN_PROGRESS=0
 
@@ -366,31 +298,16 @@ drain_handler() {
             echo "compute-source-env.sh: child did not exit in 30s, sending SIGKILL"
             kill -KILL -"$CHILD_PID" 2>/dev/null || kill -KILL "$CHILD_PID" 2>/dev/null || true
             # Reap the process so its in-flight I/O is flushed to the
-            # filesystem before we sync + unmount. SIGKILL schedules
-            # death; wait guarantees it's complete.
+            # filesystem before the launcher's cleanup unmounts the PD.
+            # SIGKILL schedules death; wait guarantees it's complete.
             wait "$CHILD_PID" 2>/dev/null || true
         fi
     fi
-    if [ "${ECLOUD_PD_EXPECTED:-0}" = "1" ] && mountpoint -q "$USERDATA_MOUNT" 2>/dev/null; then
-        sync
-        if umount "$USERDATA_MOUNT" 2>/dev/null; then
-            echo "compute-source-env.sh: unmounted $USERDATA_MOUNT cleanly"
-        else
-            # Force lazy unmount as last resort — orchestrator still needs
-            # the DETACHED signal to proceed.
-            umount -l "$USERDATA_MOUNT" 2>/dev/null || true
-            echo "compute-source-env.sh: WARNING - used lazy unmount on $USERDATA_MOUNT"
-        fi
-        # ECLOUD_DETACHED is strictly a PD-lifecycle signal. Only emit
-        # it when we actually had a PD mount in play, so serial-log
-        # parsers and alerting for non-PD apps don't see spurious
-        # lifecycle markers on routine container SIGTERM.
-        echo "ECLOUD_DETACHED"
-    fi
     # Always exit 0: drain is a managed shutdown and the orchestrator
-    # waits on ECLOUD_DETACHED, not the container exit code. Forwarding
-    # the child's exit status here would make a crash-during-drain look
-    # like a drain failure to whatever reads the container exit code.
+    # waits on the launcher's ECLOUD_DETACHED, not this container's exit
+    # code. Forwarding the child's exit status here would make a crash-
+    # during-drain look like a drain failure to whatever reads the
+    # container exit code.
     exit 0
 }
 trap drain_handler TERM
@@ -445,12 +362,16 @@ drain_watcher() {
 
 if [ "${ECLOUD_PD_EXPECTED:-0}" = "1" ]; then
     # Assumption: the orchestrator only flips ECLOUD_DRAIN_REQUESTED=1
-    # after observing ECLOUD_AWAITING_USERDATA (old VM) or
-    # ECLOUD_READY (new VM), so CHILD_PID is always set by the time
-    # drain_handler fires. If drain somehow arrived in the tiny window
-    # between this watcher spawn and CHILD_PID assignment below,
-    # drain_handler would skip the child-kill branch and still emit
-    # ECLOUD_DETACHED — harmless because there's nothing to drain yet.
+    # after observing ECLOUD_READY (new VM) or the launcher's
+    # ECLOUD_AWAITING_USERDATA emit (old VM in prewarm-detach), so
+    # CHILD_PID is always set by the time drain_handler fires. If drain
+    # somehow arrived in the tiny window between this watcher spawn and
+    # CHILD_PID assignment below, drain_handler would skip the child-
+    # kill branch — harmless because there's nothing to drain yet, and
+    # the launcher's post-exit cleanup still runs.
+    # Non-PD apps do not start a drain watcher: there's no PD lifecycle
+    # to coordinate, so the orchestrator's drain is a routine container
+    # SIGTERM that doesn't need a metadata-poll fallback.
     if [ -x /usr/local/bin/ecloud-drain-watcher ]; then
         /usr/local/bin/ecloud-drain-watcher &
     else

--- a/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
+++ b/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
@@ -348,11 +348,13 @@ drain_watcher() {
         v=$(_fetch_drain_flag || true)
         if [ "$v" = "1" ]; then
             echo "compute-source-env.sh: drain_watcher saw ECLOUD_DRAIN_REQUESTED=1, signaling PID 1"
-            # The CS launcher runs this script directly as PID 1, so
-            # kill -TERM 1 delivers SIGTERM to the shell that installed
-            # the drain_handler trap. If the launch mechanism ever
-            # wraps this script in another process, this assumption
-            # breaks and drain will silently no-op — audit here.
+            # This script runs as PID 1 within the user container's PID
+            # namespace (the cos-tdx launcher is PID 1 on the host, but
+            # that's a different namespace), so kill -TERM 1 delivers
+            # SIGTERM to the shell that installed the drain_handler trap.
+            # If the launch mechanism ever wraps this script in another
+            # process inside the container, this assumption breaks and
+            # drain will silently no-op — audit here.
             kill -TERM 1 2>/dev/null || true
             return 0
         fi

--- a/packages/sdk/src/client/common/templates/scriptTemplate.test.ts
+++ b/packages/sdk/src/client/common/templates/scriptTemplate.test.ts
@@ -40,15 +40,24 @@ describe("compute-source-env.sh.tmpl", () => {
     // Regression guard for the 2026-05-04 dev incident where an older
     // template shipped without these markers caused every deploy to
     // time out at waitForStartupReady and the platform to delete the
-    // VM. Keep all four present; the platform watches for ECLOUD_READY
-    // (success path) and ECLOUD_FAIL (any exit-1 setup failure),
-    // ECLOUD_AWAITING_USERDATA (prewarm-detach old VM), and
-    // ECLOUD_DETACHED (prewarm-detach drained old VM).
+    // VM. The script owns ECLOUD_READY (success path) and ECLOUD_FAIL
+    // (any exit-1 setup failure).
+    //
+    // The PD lifecycle markers (AWAITING_USERDATA, DETACHED) are
+    // emitted by the cos-tdx launcher (Layr-Labs/go-tpm-tools) and
+    // intentionally NOT by this script — the script lacks
+    // CAP_SYS_ADMIN to mount/umount and the launcher is the only
+    // place that work can succeed. A regression of either marker
+    // emit returning to this script indicates someone re-introduced
+    // the script-side LUKS approach that already failed in production
+    // once. We detect emission by looking at echo statements only,
+    // since the marker names appear (correctly) in header comments
+    // explaining the launcher's role.
     const rendered = render(data);
     expect(rendered).toContain("ECLOUD_READY runtime_bootstrapped");
     expect(rendered).toContain("ECLOUD_FAIL kms_bootstrap");
-    expect(rendered).toContain("ECLOUD_AWAITING_USERDATA");
-    expect(rendered).toContain("ECLOUD_DETACHED");
+    expect(rendered).not.toMatch(/^\s*echo\s+["']?ECLOUD_AWAITING_USERDATA/m);
+    expect(rendered).not.toMatch(/^\s*echo\s+["']?ECLOUD_DETACHED/m);
   });
 
   it("reads the KMS signing public key from the file the CLI lays into the image", () => {
@@ -61,14 +70,40 @@ describe("compute-source-env.sh.tmpl", () => {
     expect(rendered).toContain("cat /usr/local/bin/kms-signing-public-key.pem");
   });
 
-  it("installs the PD wait + drain-watcher machinery for prewarm-detach apps", () => {
+  it("installs the drain-watcher + SIGTERM forwarder for prewarm-detach apps", () => {
+    // After the Option A migration, the script no longer owns the PD
+    // lifecycle (mount/umount/cryptsetup) — the cos-tdx launcher does.
+    // What the script DOES own is forwarding SIGTERM to the user app
+    // for graceful shutdown, gated on ECLOUD_PD_EXPECTED so non-PD apps
+    // skip the metadata-poll fallback.
     const rendered = render(data);
-    expect(rendered).toContain("wait_for_userdata");
     expect(rendered).toContain("drain_handler");
     expect(rendered).toContain("drain_watcher");
     expect(rendered).toContain("/usr/local/bin/ecloud-drain-watcher");
     expect(rendered).toContain("ECLOUD_PD_EXPECTED");
     expect(rendered).toContain("ECLOUD_DRAIN_REQUESTED");
+  });
+
+  it("does NOT do PD mount/umount work itself (launcher owns that)", () => {
+    // Regression guard against re-introducing the script-side LUKS
+    // approach. The user container has no CAP_SYS_ADMIN by default, so
+    // any mount/umount/cryptsetup invocation here silently EPERMs in
+    // production and the user's data ends up on the boot-disk
+    // stateful partition (wiped on every reboot). See
+    // ecloud-platform docs/solutions/2026-05-15-prewarm-detach-pd-preservation-boot-race.md
+    // for the full incident. We match against non-comment lines so a
+    // future doc comment about the launcher's responsibilities (which
+    // legitimately names mount/umount/cryptsetup as launcher-side
+    // primitives) doesn't trip the guard.
+    const nonComment = render(data)
+      .split("\n")
+      .filter((line) => !/^\s*#/.test(line))
+      .join("\n");
+    expect(nonComment).not.toContain("wait_for_userdata");
+    expect(nonComment).not.toMatch(/(?:^|[;&|\s])mount\s+/m);
+    expect(nonComment).not.toMatch(/(?:^|[;&|\s])umount\s+/m);
+    expect(nonComment).not.toContain("mkfs.ext4");
+    expect(nonComment).not.toContain("cryptsetup");
   });
 
   it("backfills the dormant TLS site's cert paths so caddy validate passes", () => {


### PR DESCRIPTION
## Summary

Mirrors [`Layr-Labs/ecloud-platform#187`](https://github.com/Layr-Labs/ecloud-platform/pull/187) onto the SDK's downstream copy of `compute-source-env.sh.tmpl`. The two templates are kept in lockstep intentionally — when the SDK's `eigenx`-deployed images run inside Confidential Space, they hit the same orchestrator + cos-tdx launcher contract as platform-built images.

Companion PR in the launcher: [`Layr-Labs/go-tpm-tools#31`](https://github.com/Layr-Labs/go-tpm-tools/pull/31).

## Why now

The script's `wait_for_userdata` / drain umount block runs inside a Confidential Space user container that has no `CAP_SYS_ADMIN` by default. `cryptsetup`, `mount`, and `umount` silently EPERM'd in production and PD data ended up on the boot-disk stateful partition (wiped on every reboot). The launcher is the only place this work can actually succeed.

Background: `ecloud-platform` `docs/solutions/2026-05-15-prewarm-detach-pd-preservation-boot-race.md` and `docs/solutions/2026-05-18-prewarm-detach-pd-end-to-end-design.md` (PR #177).

## What changes

| File | Change |
|---|---|
| `packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl` | Drop `wait_for_userdata` + invocation. Drop `ECLOUD_AWAITING_USERDATA` emit. Drop drain_handler's umount / lazy-umount / `ECLOUD_DETACHED` block. **Keep** drain_handler's child SIGTERM forwarding + 30s grace + SIGKILL (still needed for graceful app shutdown), and **keep** drain_watcher (metadata poll → kill -TERM 1). Header comments rewritten to reflect launcher/script ownership split. |
| `packages/sdk/src/client/common/templates/scriptTemplate.test.ts` | Update the `emits ECLOUD lifecycle markers` test to assert only `ECLOUD_READY`/`ECLOUD_FAIL` are emitted (via `echo` regex, not anywhere in the file — so legitimate header comments naming the launcher's responsibilities don't trip it). Rename the `installs the PD wait + drain-watcher machinery` test to `installs the drain-watcher + SIGTERM forwarder` and drop the `wait_for_userdata` assertion. Add a new `does NOT do PD mount/umount work itself` regression guard that filters comments and asserts no shell-active invocation of `mount`, `umount`, `mkfs.ext4`, `cryptsetup`, or `wait_for_userdata`. |

## What does NOT change

- `ECLOUD_PD_EXPECTED` is still respected by the script (gates the drain-watcher install).
- `Dockerfile.layered.tmpl` and its test are untouched. The `tee.launch_policy.allow_env_override` allowlist still includes `ECLOUD_PD_EXPECTED` and `ECLOUD_PLATFORM_HOST`.
- `ECLOUD_READY` / `ECLOUD_FAIL` continue to be emitted by the script (post-KMS, post-TLS).

## Coordination notes

- This PR targets the `ecloud-platform` branch (NOT `master`). The prewarm-detach machinery the script is shrinking lives only on `ecloud-platform`; `master`'s SDK template is the older pre-prewarm-detach version with nothing to remove.
- This PR is safe to land before `Layr-Labs/go-tpm-tools#31` merges, but the prewarm-detach upgrade path won't fully work end-to-end until #31 lands AND a new CS image is published with the new launcher. Until then, prewarm-detach upgrades continue to loud-fail via the platform's `WaitAwaitingUserdata` strict gate (not a regression — same loud-failing behavior as today).

## Test plan

- [x] `vitest run --root packages/sdk packages/sdk/src/client/common/templates/` — 12/12 pass
- [x] `vitest run --root packages/sdk` — 38/38 pass (full SDK suite)
- [x] `vitest run --root packages/sdk packages/sdk/src/client/common/templates/dockerfileTemplate.test.ts` — 5/5 pass (Dockerfile contract intact)
- [x] `tsc --noEmit -p packages/sdk` — clean
- [x] Pre-existing lint warnings in unrelated files (`environment.ts`, `eip7702.ts`, `layer.ts`) confirmed pre-existing on `origin/ecloud-platform` baseline — out of scope.
- [ ] After `Layr-Labs/go-tpm-tools#31` merges + new CS image is published: e2e validation against an `eigenx`-deployed PD-backed app exercising prewarm-detach upgrade.