### PR TITLE
fix: ship CA bundle in layered image for kms-client TLS

### DIFF
--- a/packages/sdk/src/client/common/templates/Dockerfile.layered.tmpl
+++ b/packages/sdk/src/client/common/templates/Dockerfile.layered.tmpl
@@ -11,6 +11,11 @@ USER root
 {{/if}}
 
 # Copy core TEE components
+# CA bundle for kms-client / tls-keygen to validate HTTPS calls to
+# eigencloud.xyz endpoints. Bundled at a non-standard path and consumed
+# only via SSL_CERT_FILE in compute-source-env.sh, so the user's
+# /etc/ssl/ is never touched.
+COPY --from=alpine:3.20.10 /etc/ssl/certs/ca-certificates.crt /usr/local/share/eigenx-ca-certs.crt
 COPY compute-source-env.sh /usr/local/bin/
 COPY kms-client /usr/local/bin/
 COPY kms-signing-public-key.pem /usr/local/bin/

--- a/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
+++ b/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
@@ -3,7 +3,7 @@ echo "compute-source-env.sh: Running setup script..."
 
 # Fetch and source environment variables from KMS
 echo "Fetching secrets from KMS..."
-if /usr/local/bin/kms-client \
+if SSL_CERT_FILE=/usr/local/share/eigenx-ca-certs.crt /usr/local/bin/kms-client \
   --kms-server-url "{{kmsServerURL}}" \
   --kms-signing-key-file /usr/local/bin/kms-signing-public-key.pem \
   --userapi-url "{{userAPIURL}}" \

--- a/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
+++ b/packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl
@@ -61,7 +61,8 @@ setup_tls() {
     
     echo "compute-source-env.sh: Obtaining TLS certificate using $challenge challenge..."
     # Pass the API URL for certificate persistence
-    if ! MNEMONIC="$mnemonic" DOMAIN="$domain" API_URL="{{userAPIURL}}" /usr/local/bin/tls-keygen \
+    if ! SSL_CERT_FILE=/usr/local/share/eigenx-ca-certs.crt \
+       MNEMONIC="$mnemonic" DOMAIN="$domain" API_URL="{{userAPIURL}}" /usr/local/bin/tls-keygen \
         -challenge "$challenge" \
         $staging_flag; then
         echo "compute-source-env.sh: ERROR - Failed to obtain TLS certificate"


### PR DESCRIPTION
## Summary

The kms-client binary copied into the layered image makes HTTPS calls to `userapi-compute*.eigencloud.xyz/v2/attestation`, but the layered image only inherits whatever CA store the user's base image happens to ship. Minimal bases (alpine without ca-certificates, scratch, distroless, custom slim images) lack one, causing kms-client to fail the TLS handshake with `x509: certificate signed by unknown authority`. Attestation upload is silently abandoned (29 retries, then logged as ERROR but non-fatal); the workload still starts but its attestation never reaches the user API and the verify dashboard shows "No attestations available."

Confirmed live: a vTPM app on mainnet (`0x751847d2c430e3b5a843d017ea8d0a3d453377d0`) — built with this CLI/SDK — has 36 releases, status=Running, but `v2_count=0`. Boot logs show 30 retries against the userapi `/v2/attestation` URL all failing with `x509: certificate signed by unknown authority`.

Parity with the compute-tee and ecloud-platform fixes landing in parallel.

## Fix

- Copy alpine `3.20.10`'s CA bundle to `/usr/local/share/eigenx-ca-certs.crt` in the layered image (non-standard path, does NOT touch the user's `/etc/ssl/`).
- Prefix the kms-client invocation in `compute-source-env.sh` with `SSL_CERT_FILE=` pointing at that path. The env-var override is scoped to the single kms-client process — the user's runtime never sees it.
- Alpine pinned to `3.20.10` for build determinism.

## Files changed

- `packages/sdk/src/client/common/templates/Dockerfile.layered.tmpl`
- `packages/sdk/src/client/common/templates/compute-source-env.sh.tmpl`

## Test plan

- [x] Build a layered image from a base without `ca-certificates` (e.g. `alpine` with no extras, or `scratch`/distroless) and confirm `/usr/local/share/eigenx-ca-certs.crt` is present. _(verified locally — see comment below)_
- [x] Confirm the user's `/etc/ssl/` is unchanged inside the running container, and `SSL_CERT_FILE` is not set in the user workload's environment. _(verified locally — see comment below)_
- [x] Existing layered-image builds with bases that already have `ca-certificates` continue to work unchanged. _(verified locally — see comment below)_

