### PR TITLE
fix(cli): spread commonFlags on billing cancel (RND-567)

### DIFF
--- a/packages/cli/src/commands/billing/cancel.ts
+++ b/packages/cli/src/commands/billing/cancel.ts
@@ -10,8 +10,7 @@ export default class BillingCancel extends Command {
   static description = "Cancel subscription";
 
   static flags = {
-    "private-key": commonFlags["private-key"],
-    verbose: commonFlags.verbose,
+    ...commonFlags,
     product: Flags.string({
       required: false,
       description: "Product ID",


### PR DESCRIPTION
## Summary

`ecloud billing cancel` cherry-picked only `private-key` and `verbose` from `commonFlags`, leaving `--environment` (and `--rpc-url`, `--max-fee-per-gas`, `--max-priority-fee`, `--nonce`) undeclared. That made the command unusable in CI / scripted flows: `--environment sepolia-dev` errored with `Nonexistent flag: --environment`, and `ECLOUD_ENV=sepolia-dev` was ignored because the env binding lives on `commonFlags.environment`.

This change spreads `...commonFlags` like every other billing subcommand (`status`, `subscribe`, `top-up`, `list-cards`), keeping `product` and `force` flags on top.

Resolves [RND-567](https://linear.app/eigenlabs/issue/RND-567).

## Test plan

- [x] `pnpm --filter @layr-labs/ecloud-cli run build:dev` passes
- [x] `pnpm --filter @layr-labs/ecloud-cli run typecheck` clean for `cancel.ts` (only pre-existing unrelated test-globals errors)
- [x] `eslint src/commands/billing/cancel.ts` clean
- [x] `ecloud billing cancel --help` now lists `--environment`, `--rpc-url`, `--max-fee-per-gas`, `--max-priority-fee`, `--nonce`
- [x] Live: `ecloud billing cancel --environment sepolia-dev --force --private-key …` reaches the cancellation flow (no "Nonexistent flag" / "Cannot prompt")