### PR TITLE
fix(cli): non-interactive watch timeouts + billing cancel flags (RND-567 / RND-568 / RND-569)

### DIFF
--- a/packages/cli/src/commands/billing/cancel.ts
+++ b/packages/cli/src/commands/billing/cancel.ts
@@ -10,8 +10,7 @@ export default class BillingCancel extends Command {
   static description = "Cancel subscription";
 
   static flags = {
-    "private-key": commonFlags["private-key"],
-    verbose: commonFlags.verbose,
+    ...commonFlags,
     product: Flags.string({
       required: false,
       description: "Product ID",

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -1,5 +1,10 @@
 import { Command, Flags } from "@oclif/core";
-import { getEnvironmentConfig, UserApiClient, isMainnet } from "@layr-labs/ecloud-sdk";
+import {
+  getEnvironmentConfig,
+  UserApiClient,
+  isMainnet,
+  WatchTimeoutError,
+} from "@layr-labs/ecloud-sdk";
 import { withTelemetry } from "../../../telemetry";
 import { commonFlags, applyTxOverrides } from "../../../flags";
 import { createComputeClient } from "../../../client";
@@ -146,6 +151,11 @@ export default class AppDeploy extends Command {
     force: Flags.boolean({
       description: "Skip all confirmation prompts",
       default: false,
+    }),
+    "watch-timeout": Flags.integer({
+      description:
+        "Maximum seconds to wait for the app to start before returning a recovery hint (default: 600)",
+      env: "ECLOUD_WATCH_TIMEOUT_SECONDS",
     }),
   };
 
@@ -533,7 +543,41 @@ export default class AppDeploy extends Command {
       }
 
       // 12. Watch until app is running
-      const ipAddress = await compute.app.watchDeployment(res.appId);
+      let ipAddress: string | undefined;
+      try {
+        ipAddress = await compute.app.watchDeployment(res.appId, {
+          timeoutSeconds: flags["watch-timeout"],
+        });
+      } catch (watchErr: any) {
+        if (watchErr instanceof WatchTimeoutError) {
+          this.log(
+            `\n${chalk.yellow("⚠")} ${chalk.yellow(
+              `Deployment did not reach Running within ${watchErr.elapsedSeconds}s (last status: ${watchErr.lastStatus ?? "unknown"}).`,
+            )}`,
+          );
+          this.log(
+            chalk.gray(
+              `The deploy transaction succeeded, but the orchestrator hasn't reported the app as Running yet.`,
+            ),
+          );
+          this.log(chalk.gray(`  appId:  ${res.appId}`));
+          if (res.txHash) {
+            this.log(chalk.gray(`  txHash: ${res.txHash}`));
+          }
+          this.log(
+            chalk.gray(
+              `Check progress later with: ${chalk.cyan(`ecloud compute app info ${res.appId}`)}`,
+            ),
+          );
+          this.log(
+            chalk.gray(
+              `Override the watch timeout with the ${chalk.cyan("ECLOUD_WATCH_TIMEOUT_SECONDS")} environment variable.`,
+            ),
+          );
+          this.exit(1);
+        }
+        throw watchErr;
+      }
 
       try {
         const cwd = process.env.INIT_CWD || process.cwd();

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -1,5 +1,10 @@
 import { Command, Args, Flags } from "@oclif/core";
-import { getEnvironmentConfig, UserApiClient, isMainnet } from "@layr-labs/ecloud-sdk";
+import {
+  getEnvironmentConfig,
+  UserApiClient,
+  isMainnet,
+  WatchTimeoutError,
+} from "@layr-labs/ecloud-sdk";
 import { withTelemetry } from "../../../telemetry";
 import { commonFlags, applyTxOverrides } from "../../../flags";
 import { createBuildClient, createComputeClient } from "../../../client";
@@ -129,6 +134,11 @@ export default class AppUpgrade extends Command {
     force: Flags.boolean({
       description: "Skip all confirmation prompts",
       default: false,
+    }),
+    "watch-timeout": Flags.integer({
+      description:
+        "Maximum seconds to wait for the upgrade to complete before returning a recovery hint (default: 600)",
+      env: "ECLOUD_WATCH_TIMEOUT_SECONDS",
     }),
   };
 
@@ -407,7 +417,32 @@ export default class AppUpgrade extends Command {
       const res = await compute.app.executeUpgrade(prepared, finalTx);
 
       // 12. Watch until upgrade completes
-      await compute.app.watchUpgrade(res.appId);
+      try {
+        await compute.app.watchUpgrade(res.appId, { timeoutSeconds: flags["watch-timeout"] });
+      } catch (err: any) {
+        if (err instanceof WatchTimeoutError) {
+          this.log("");
+          this.log(
+            chalk.yellow(
+              `Timed out after ${err.elapsedSeconds}s waiting for upgrade to complete (last status: ${err.lastStatus ?? "unknown"}).`,
+            ),
+          );
+          this.log(chalk.gray("The on-chain transaction was submitted; the orchestrator may"));
+          this.log(chalk.gray("still be processing. To check the current status, run:"));
+          this.log("");
+          this.log(`  ${chalk.cyan(`ecloud compute app info ${res.appId}`)}`);
+          this.log("");
+          this.log(chalk.gray(`appId:  ${res.appId}`));
+          this.log(chalk.gray(`txHash: ${res.txHash}`));
+          this.log(
+            chalk.gray(
+              `(override the watch deadline with ECLOUD_WATCH_TIMEOUT_SECONDS, currently ${err.timeoutSeconds}s)`,
+            ),
+          );
+          this.exit(1);
+        }
+        throw err;
+      }
 
       try {
         const cwd = process.env.INIT_CWD || process.cwd();

--- a/packages/sdk/src/client/common/contract/watcher.ts
+++ b/packages/sdk/src/client/common/contract/watcher.ts
@@ -122,20 +122,83 @@ export interface WatchUntilUpgradeCompleteOptions {
   publicClient: PublicClient;
   environmentConfig: EnvironmentConfig;
   appId: Address;
+  /**
+   * Maximum time (in seconds) to wait for the upgrade to complete before
+   * throwing a {@link WatchTimeoutError}. If unspecified, defaults to
+   * the value of the `ECLOUD_WATCH_TIMEOUT_SECONDS` env var, falling back to
+   * {@link WATCH_DEFAULT_TIMEOUT_SECONDS}.
+   */
+  timeoutSeconds?: number;
 }
 
 const APP_STATUS_STOPPED = "Stopped";
 
+/** Default upgrade watch timeout: 10 minutes. */
+export const WATCH_DEFAULT_TIMEOUT_SECONDS = 10 * 60;
+
+/**
+ * Error thrown when {@link watchUntilUpgradeComplete} exceeds its deadline
+ * without observing a terminal status (Stopped or Running) for the app.
+ *
+ * Callers (e.g. the CLI) can catch this and surface a recovery hint pointing
+ * the user at `ecloud compute app info <appId>`.
+ */
+export class WatchTimeoutError extends Error {
+  public readonly appId: Address;
+  public readonly lastStatus: string | undefined;
+  public readonly elapsedSeconds: number;
+  public readonly timeoutSeconds: number;
+
+  constructor(params: {
+    appId: Address;
+    lastStatus: string | undefined;
+    elapsedSeconds: number;
+    timeoutSeconds: number;
+  }) {
+    super(
+      `Timed out after ${params.elapsedSeconds}s waiting for upgrade to complete (last status: ${
+        params.lastStatus ?? "unknown"
+      })`,
+    );
+    this.name = "WatchTimeoutError";
+    this.appId = params.appId;
+    this.lastStatus = params.lastStatus;
+    this.elapsedSeconds = params.elapsedSeconds;
+    this.timeoutSeconds = params.timeoutSeconds;
+  }
+}
+
+/**
+ * Resolve the upgrade watch timeout from explicit option, env var, or default.
+ */
+function resolveWatchTimeoutSeconds(explicit?: number): number {
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return explicit;
+  }
+  const fromEnv = process.env.ECLOUD_WATCH_TIMEOUT_SECONDS;
+  if (fromEnv) {
+    const parsed = Number.parseInt(fromEnv, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return WATCH_DEFAULT_TIMEOUT_SECONDS;
+}
+
 /**
  * Watch app until upgrade completes
  * For upgrades, we watch until the app reaches Stopped status (upgrade complete)
- * or Running status (if it was running before upgrade)
+ * or Running status (if it was running before upgrade).
+ *
+ * Throws {@link WatchTimeoutError} if the timeout elapses before a
+ * terminal status is observed.
  */
 export async function watchUntilUpgradeComplete(
   options: WatchUntilUpgradeCompleteOptions,
   logger: Logger,
 ): Promise<void> {
   const { walletClient, publicClient, environmentConfig, appId } = options;
+  const timeoutSeconds = resolveWatchTimeoutSeconds(options.timeoutSeconds);
 
   // Create UserAPI client
   const userApiClient = new UserApiClient(environmentConfig, walletClient, publicClient);
@@ -193,7 +256,21 @@ export async function watchUntilUpgradeComplete(
   };
 
   // Main watch loop
+  const startTime = Date.now();
+  const deadline = startTime + timeoutSeconds * 1000;
+  let lastLoggedStatus: string | undefined;
+  let lastObservedStatus: string | undefined;
   while (true) {
+    if (Date.now() >= deadline) {
+      const elapsedSeconds = Math.round((Date.now() - startTime) / 1000);
+      throw new WatchTimeoutError({
+        appId,
+        lastStatus: lastObservedStatus,
+        elapsedSeconds,
+        timeoutSeconds,
+      });
+    }
+
     try {
       // Fetch app info
       const info = await userApiClient.getInfos([appId], 1);
@@ -205,6 +282,14 @@ export async function watchUntilUpgradeComplete(
       const appInfo = info[0];
       const currentStatus = appInfo.status;
       const currentIP = appInfo.ip || "";
+      lastObservedStatus = currentStatus;
+
+      // Log status changes and elapsed time on a new line per transition
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      if (currentStatus !== lastLoggedStatus) {
+        logger.info(`Status: ${currentStatus} (${elapsed}s)`);
+        lastLoggedStatus = currentStatus;
+      }
 
       // Check stop condition
       if (stopCondition(currentStatus, currentIP)) {
@@ -214,6 +299,14 @@ export async function watchUntilUpgradeComplete(
       // Wait before next poll
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     } catch (error: any) {
+      // Re-throw timeout errors and terminal failures from stopCondition.
+      if (error instanceof WatchTimeoutError) {
+        throw error;
+      }
+      // Heuristic: stopCondition throws plain Error for "Failed" state — let it propagate.
+      if (typeof error?.message === "string" && error.message.includes("Failed")) {
+        throw error;
+      }
       logger.warn(`Failed to fetch app info: ${error.message}`);
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     }

--- a/packages/sdk/src/client/common/contract/watcher.ts
+++ b/packages/sdk/src/client/common/contract/watcher.ts
@@ -17,12 +17,69 @@ export interface WatchUntilRunningOptions {
   publicClient: PublicClient;
   environmentConfig: EnvironmentConfig;
   appId: Address;
+  /**
+   * Maximum seconds to wait before throwing {@link WatchTimeoutError}.
+   * Precedence: explicit value > `ECLOUD_WATCH_TIMEOUT_SECONDS` env var > 600s default.
+   */
+  timeoutSeconds?: number;
 }
 
 const WATCH_POLL_INTERVAL_SECONDS = 5;
+const WATCH_HEARTBEAT_INTERVAL_SECONDS = 30;
+export const WATCH_DEFAULT_TIMEOUT_SECONDS = 10 * 60;
 const APP_STATUS_RUNNING = "Running";
 const APP_STATUS_FAILED = "Failed";
 // const APP_STATUS_DEPLOYING = 'Deploying';
+
+/**
+ * Typed error thrown when watch loops exceed their timeout budget.
+ *
+ * Callers (e.g. the CLI) can catch this specifically to surface a
+ * troubleshooting hint without treating it as a generic failure.
+ */
+export class WatchTimeoutError extends Error {
+  public readonly appId: string;
+  public readonly elapsedSeconds: number;
+  public readonly lastStatus: string | undefined;
+  public readonly timeoutSeconds: number;
+
+  constructor(args: {
+    appId: string;
+    elapsedSeconds: number;
+    lastStatus: string | undefined;
+    timeoutSeconds: number;
+    message?: string;
+  }) {
+    super(
+      args.message ??
+        `Timed out after ${args.elapsedSeconds}s waiting for app ${args.appId} (last status: ${args.lastStatus ?? "unknown"})`,
+    );
+    this.name = "WatchTimeoutError";
+    this.appId = args.appId;
+    this.elapsedSeconds = args.elapsedSeconds;
+    this.lastStatus = args.lastStatus;
+    this.timeoutSeconds = args.timeoutSeconds;
+  }
+}
+
+/**
+ * Resolve the watch timeout in seconds, honoring the
+ * ECLOUD_WATCH_TIMEOUT_SECONDS environment override.
+ */
+function resolveWatchTimeoutSeconds(explicit?: number): number {
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return Math.floor(explicit);
+  }
+  const raw = process.env.ECLOUD_WATCH_TIMEOUT_SECONDS;
+  if (raw === undefined || raw === "") {
+    return WATCH_DEFAULT_TIMEOUT_SECONDS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return WATCH_DEFAULT_TIMEOUT_SECONDS;
+  }
+  return Math.floor(parsed);
+}
 
 /**
  * Watch app until it reaches Running status with IP address
@@ -79,8 +136,23 @@ export async function watchUntilRunning(
 
   // Main watch loop
   const startTime = Date.now();
+  const timeoutSeconds = resolveWatchTimeoutSeconds(options.timeoutSeconds);
   let lastLoggedStatus: string | undefined;
+  let lastHeartbeatAt = startTime;
   while (true) {
+    const elapsedMs = Date.now() - startTime;
+    const elapsed = Math.round(elapsedMs / 1000);
+
+    // Bound the loop: surface a typed timeout so callers can hint the user.
+    if (elapsed >= timeoutSeconds) {
+      throw new WatchTimeoutError({
+        appId,
+        elapsedSeconds: elapsed,
+        lastStatus: lastLoggedStatus,
+        timeoutSeconds,
+      });
+    }
+
     try {
       // Fetch app info
       const info = await userApiClient.getInfos([appId], 1);
@@ -93,11 +165,16 @@ export async function watchUntilRunning(
       const currentStatus = appInfo.status;
       const currentIP = appInfo.ip || "";
 
-      // Log status changes and elapsed time
-      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      // Log status transitions, plus a periodic heartbeat so non-TTY
+      // stdout (where carriage-return updates are invisible) still shows
+      // progress when the status string is unchanged for a long time.
       if (currentStatus !== lastLoggedStatus) {
         logger.info(`Status: ${currentStatus} (${elapsed}s)`);
         lastLoggedStatus = currentStatus;
+        lastHeartbeatAt = Date.now();
+      } else if (Date.now() - lastHeartbeatAt >= WATCH_HEARTBEAT_INTERVAL_SECONDS * 1000) {
+        logger.info(`Status: ${currentStatus} (${elapsed}s)`);
+        lastHeartbeatAt = Date.now();
       }
 
       // Check stop condition
@@ -108,6 +185,10 @@ export async function watchUntilRunning(
       // Wait before next poll
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     } catch (error: any) {
+      // Re-throw typed terminal errors so the caller can react to them.
+      if (error instanceof WatchTimeoutError) {
+        throw error;
+      }
       logger.warn(`Failed to fetch app info: ${error.message}`);
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     }

--- a/packages/sdk/src/client/common/contract/watcher.ts
+++ b/packages/sdk/src/client/common/contract/watcher.ts
@@ -214,57 +214,8 @@ export interface WatchUntilUpgradeCompleteOptions {
 
 const APP_STATUS_STOPPED = "Stopped";
 
-/** Default upgrade watch timeout: 10 minutes. */
-export const WATCH_DEFAULT_TIMEOUT_SECONDS = 10 * 60;
-
-/**
- * Error thrown when {@link watchUntilUpgradeComplete} exceeds its deadline
- * without observing a terminal status (Stopped or Running) for the app.
- *
- * Callers (e.g. the CLI) can catch this and surface a recovery hint pointing
- * the user at `ecloud compute app info <appId>`.
- */
-export class WatchTimeoutError extends Error {
-  public readonly appId: Address;
-  public readonly lastStatus: string | undefined;
-  public readonly elapsedSeconds: number;
-  public readonly timeoutSeconds: number;
-
-  constructor(params: {
-    appId: Address;
-    lastStatus: string | undefined;
-    elapsedSeconds: number;
-    timeoutSeconds: number;
-  }) {
-    super(
-      `Timed out after ${params.elapsedSeconds}s waiting for upgrade to complete (last status: ${
-        params.lastStatus ?? "unknown"
-      })`,
-    );
-    this.name = "WatchTimeoutError";
-    this.appId = params.appId;
-    this.lastStatus = params.lastStatus;
-    this.elapsedSeconds = params.elapsedSeconds;
-    this.timeoutSeconds = params.timeoutSeconds;
-  }
-}
-
-/**
- * Resolve the upgrade watch timeout from explicit option, env var, or default.
- */
-function resolveWatchTimeoutSeconds(explicit?: number): number {
-  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
-    return explicit;
-  }
-  const fromEnv = process.env.ECLOUD_WATCH_TIMEOUT_SECONDS;
-  if (fromEnv) {
-    const parsed = Number.parseInt(fromEnv, 10);
-    if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed;
-    }
-  }
-  return WATCH_DEFAULT_TIMEOUT_SECONDS;
-}
+// WATCH_DEFAULT_TIMEOUT_SECONDS, WatchTimeoutError, and resolveWatchTimeoutSeconds
+// are shared with watchUntilRunning and declared once near the top of this file.
 
 /**
  * Watch app until upgrade completes

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -47,7 +47,9 @@ export {
   executeUpgrade,
   watchUpgrade,
   type PrepareUpgradeResult,
+  type WatchUpgradeOptions,
 } from "./modules/compute/app/upgrade";
+export { WatchTimeoutError, WATCH_DEFAULT_TIMEOUT_SECONDS } from "./common/contract/watcher";
 
 // Export compute module for standalone use
 export {

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -39,6 +39,7 @@ export {
   executeDeploy,
   watchDeployment,
   type PrepareDeployResult,
+  type WatchDeploymentOptions,
 } from "./modules/compute/app/deploy";
 export {
   SDKUpgradeOptions,
@@ -111,6 +112,9 @@ export {
   type GasEstimate,
   type EstimateGasOptions,
 } from "./common/contract/caller";
+
+// Export watcher errors so callers can react to typed terminal failures.
+export { WatchTimeoutError } from "./common/contract/watcher";
 
 // Export batch gas estimation and delegation check
 export {

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -115,9 +115,6 @@ export {
   type EstimateGasOptions,
 } from "./common/contract/caller";
 
-// Export watcher errors so callers can react to typed terminal failures.
-export { WatchTimeoutError } from "./common/contract/watcher";
-
 // Export batch gas estimation and delegation check
 export {
   estimateBatchGas,

--- a/packages/sdk/src/client/modules/compute/app/deploy.ts
+++ b/packages/sdk/src/client/modules/compute/app/deploy.ts
@@ -711,6 +711,10 @@ export async function executeDeploy(options: ExecuteDeployOptions): Promise<Depl
  * Call this after executeDeploy to wait for the app to be provisioned.
  * Can be called separately to allow for intermediate operations (e.g., profile upload).
  */
+export interface WatchDeploymentOptions {
+  timeoutSeconds?: number;
+}
+
 export async function watchDeployment(
   appId: string,
   walletClient: WalletClient,
@@ -718,6 +722,7 @@ export async function watchDeployment(
   environmentConfig: EnvironmentConfig,
   logger: Logger = defaultLogger,
   skipTelemetry?: boolean,
+  opts?: WatchDeploymentOptions,
 ): Promise<string | undefined> {
   return withSDKTelemetry(
     {
@@ -735,6 +740,7 @@ export async function watchDeployment(
           publicClient,
           environmentConfig,
           appId: appId as Address,
+          timeoutSeconds: opts?.timeoutSeconds,
         },
         logger,
       );

--- a/packages/sdk/src/client/modules/compute/app/index.ts
+++ b/packages/sdk/src/client/modules/compute/app/index.ts
@@ -23,6 +23,7 @@ import {
   prepareUpgradeFromVerifiableBuild as prepareUpgradeFromVerifiableBuildFn,
   executeUpgrade as executeUpgradeFn,
   watchUpgrade as watchUpgradeFn,
+  type WatchUpgradeOptions,
 } from "./upgrade";
 import { createApp, CreateAppOpts } from "./create";
 import { logs, LogsOptions } from "./logs";
@@ -143,7 +144,7 @@ export interface AppModule {
     gasEstimate: GasEstimate;
   }>;
   executeUpgrade: (prepared: PreparedUpgrade, gas?: GasEstimate) => Promise<ExecuteUpgradeResult>;
-  watchUpgrade: (appId: AppId) => Promise<void>;
+  watchUpgrade: (appId: AppId, opts?: WatchUpgradeOptions) => Promise<void>;
 
   // Profile management
   setProfile: (appId: AppId, profile: AppProfile) => Promise<AppProfileResponse>;
@@ -383,8 +384,16 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
       };
     },
 
-    async watchUpgrade(appId) {
-      return watchUpgradeFn(appId, walletClient, publicClient, environment, logger, skipTelemetry);
+    async watchUpgrade(appId, opts) {
+      return watchUpgradeFn(
+        appId,
+        walletClient,
+        publicClient,
+        environment,
+        logger,
+        skipTelemetry,
+        opts,
+      );
     },
 
     // Profile management

--- a/packages/sdk/src/client/modules/compute/app/index.ts
+++ b/packages/sdk/src/client/modules/compute/app/index.ts
@@ -16,6 +16,7 @@ import {
   prepareDeployFromVerifiableBuild as prepareDeployFromVerifiableBuildFn,
   executeDeploy as executeDeployFn,
   watchDeployment as watchDeploymentFn,
+  type WatchDeploymentOptions,
 } from "./deploy";
 import {
   upgrade as upgradeApp,
@@ -125,7 +126,10 @@ export interface AppModule {
     gasEstimate: GasEstimate;
   }>;
   executeDeploy: (prepared: PreparedDeploy, gas?: GasEstimate) => Promise<ExecuteDeployResult>;
-  watchDeployment: (appId: AppId) => Promise<string | undefined>;
+  watchDeployment: (
+    appId: AppId,
+    opts?: WatchDeploymentOptions,
+  ) => Promise<string | undefined>;
 
   // Granular upgrade control
   prepareUpgrade: (
@@ -314,7 +318,7 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
       };
     },
 
-    async watchDeployment(appId) {
+    async watchDeployment(appId, opts) {
       return watchDeploymentFn(
         appId,
         walletClient,
@@ -322,6 +326,7 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
         environment,
         logger,
         skipTelemetry,
+        opts,
       );
     },
 

--- a/packages/sdk/src/client/modules/compute/app/upgrade.ts
+++ b/packages/sdk/src/client/modules/compute/app/upgrade.ts
@@ -543,6 +543,10 @@ export async function executeUpgrade(options: ExecuteUpgradeOptions): Promise<Up
  * Call this after executeUpgrade to wait for the upgrade to finish.
  * Can be called separately to allow for intermediate operations.
  */
+export interface WatchUpgradeOptions {
+  timeoutSeconds?: number;
+}
+
 export async function watchUpgrade(
   appId: string,
   walletClient: WalletClient,
@@ -550,6 +554,7 @@ export async function watchUpgrade(
   environmentConfig: EnvironmentConfig,
   logger: Logger = defaultLogger,
   skipTelemetry?: boolean,
+  opts?: WatchUpgradeOptions,
 ): Promise<void> {
   return withSDKTelemetry(
     {
@@ -567,6 +572,7 @@ export async function watchUpgrade(
           publicClient,
           environmentConfig,
           appId: appId as Address,
+          timeoutSeconds: opts?.timeoutSeconds,
         },
         logger,
       );


### PR DESCRIPTION
Consolidates three CLI fixes into one PR (folds in #160 and #161).

## Included fixes

- **RND-567** (was #160) — `fix(cli): spread commonFlags on billing cancel`. `billing cancel` was missing the common flags (`--private-key`, `--environment`, etc.), making it unrunnable non-interactively.
- **RND-568** (was #161) — `fix(cli): bound upgrade watch with timeout and progress`. `watchUntilUpgradeComplete` could hang forever; now bounded by a timeout that throws a typed `WatchTimeoutError`, with periodic progress.
- **RND-569** (this branch) — `fix(cli): bound deploy watch with timeout and heartbeat`. Same treatment for `watchUntilRunning`, plus a heartbeat so non-TTY stdout shows progress when the status string is unchanged.

## Consolidation note

RND-568 and RND-569 independently introduced the same watcher primitives (`WATCH_DEFAULT_TIMEOUT_SECONDS`, `WatchTimeoutError`, `resolveWatchTimeoutSeconds`). The merge kept both copies; a follow-up commit dedupes them to a single shared definition in `watcher.ts` (the superset — includes the heartbeat interval and optional `message`) and a single export in `client/index.ts`. Both watch functions now share one timeout helper.

## Testing

- [x] `sdk` + `cli` build clean
- [x] SDK `tsc --noEmit` clean (0 errors)
- [x] 23 SDK tests pass
- [x] 61 CLI tests pass
- [x] `eslint` clean on all changed files
- [x] No duplicate declarations / merge markers remain

Supersedes #160 and #161 (closed in favor of this PR). Targets `release/v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)