### PR TITLE
fix(cli): reject --verifiable + --dockerfile up front on deploy/upgrade (RND-572)

### DIFF
--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -233,13 +233,20 @@ export default class AppDeploy extends Command {
       };
 
       if (flags.verifiable) {
+        if (flags.dockerfile) {
+          this.error(
+            "--verifiable cannot be combined with --dockerfile. Choose one: verifiable build (--repo/--commit or --image-ref) or local Dockerfile build.",
+          );
+        }
         // Explicit verifiable mode via flag: infer source based on provided flags.
         if (flags.repo || flags.commit) {
           verifiableMode = "git";
-          if (!flags.repo)
+          if (!flags.repo) {
             this.error("--repo is required when using --verifiable (git source mode)");
-          if (!flags.commit)
+          }
+          if (!flags.commit) {
             this.error("--commit is required when using --verifiable (git source mode)");
+          }
           try {
             assertCommitSha40(flags.commit);
           } catch (e: any) {

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -170,12 +170,19 @@ export default class AppUpgrade extends Command {
       let envFilePath: string | undefined;
 
       if (flags.verifiable) {
+        if (flags.dockerfile) {
+          this.error(
+            "--verifiable cannot be combined with --dockerfile. Choose one: verifiable build (--repo/--commit or --image-ref) or local Dockerfile build.",
+          );
+        }
         if (flags.repo || flags.commit) {
           verifiableMode = "git";
-          if (!flags.repo)
+          if (!flags.repo) {
             this.error("--repo is required when using --verifiable (git source mode)");
-          if (!flags.commit)
+          }
+          if (!flags.commit) {
             this.error("--commit is required when using --verifiable (git source mode)");
+          }
           try {
             assertCommitSha40(flags.commit);
           } catch (e: any) {

--- a/packages/cli/src/utils/dockerhub.ts
+++ b/packages/cli/src/utils/dockerhub.ts
@@ -15,7 +15,9 @@ export function parseEigencloudContainersImageRef(imageRef: string): DockerHubIm
   const trimmed = imageRef.trim();
   const match = /^docker\.io\/([^/]+)\/([^:@]+):([^@\s]+)$/i.exec(trimmed);
   if (!match) {
-    throw new Error("Image ref must match docker.io/eigenlayer/eigencloud-containers:<tag>");
+    throw new Error(
+      `Image ref "${imageRef}" is not a valid prebuilt verifiable image. Expected format: docker.io/${DOCKERHUB_OWNER}/${DOCKERHUB_REPO}:<tag>`,
+    );
   }
 
   const owner = match[1]!.toLowerCase();


### PR DESCRIPTION
## Summary

Passing `--verifiable` together with `--dockerfile` and `--image-ref` previously fell through to `assertEigencloudContainersImageRef` and surfaced the misleading `Image ref must match docker.io/eigenlayer/eigencloud-containers:<tag>` error. The actual issue is that `--verifiable` is incompatible with a local Dockerfile build: the verifiable flow only supports git source (`--repo/--commit`) or a prebuilt image (`--image-ref`).

- Add an explicit guard at the top of the verifiable branch in `deploy.ts` and `upgrade.ts` that fails with a clear, actionable message before any registry validation runs.
- Loosen `dockerhub.ts:18` wording to clarify the regex check is about the prebuilt verifiable image format, including the offending value for context.
- Add braces to the existing `if (!flags.repo)` / `if (!flags.commit)` guards in both commands (single-statement `if` without braces is easy to misread when surrounded by other branching logic).

Resolves [RND-572](https://linear.app/eigenlabs/issue/RND-572).

## Test plan

- [x] `pnpm --filter @layr-labs/ecloud-cli run build:dev` clean
- [x] `typecheck` clean for the touched files (only pre-existing unrelated test-globals errors)
- [x] `eslint` clean on touched files
- [x] **Repro from the issue** now fails fast (no network call) with the new message:
  ```
  $ ecloud compute app deploy --verifiable --dockerfile Dockerfile --image-ref foo:bar --environment sepolia-dev --force ...
  Error: --verifiable cannot be combined with --dockerfile. Choose one: verifiable build (--repo/--commit or --image-ref) or local Dockerfile build.
  ```
- [x] Same error from `compute app upgrade ... --verifiable --dockerfile ... --image-ref ...`