### PR TITLE
fix(cli): agent-friendly deploy/upgrade — non-interactive defaults, app status --wait, staged exit codes, gas pre-flight + amd64 hardening (RND-589/591/592/596/597 + RND-567/568/569)

### DIFF
--- a/packages/cli/skills/deploy/SKILL.md
+++ b/packages/cli/skills/deploy/SKILL.md
@@ -28,7 +28,7 @@ You are deploying to EigenCloud TEE (Trusted Execution Environment) infrastructu
 
 5. **Derived keys (EVM + Solana wallets) are deterministic per app ID.** They persist across stop/start/upgrade. They are permanently lost if you terminate and redeploy — new app ID means new keys.
 
-6. **`--json` is only available on:** `app releases`, `build submit`, `build status`, `build info`, `build list`, `build verify`. It is NOT available on: `app list`, `app info`, `app deploy`, `billing status`. Do not pass `--json` to commands that don't support it.
+6. **`--json` is only available on:** `app status`, `app releases`, `build submit`, `build status`, `build info`, `build list`, `build verify`. It is NOT available on: `app list`, `app info`, `app deploy`, `billing status`. Do not pass `--json` to commands that don't support it.
 
 7. **No `--dry-run` exists** anywhere in the CLI. No `--yes` on deploy/upgrade (they don't prompt interactively). `--force` only exists on: `app terminate`, `billing cancel`, `auth logout`.
 
@@ -51,6 +51,7 @@ Run all five checks. Fix any that fail before proceeding.
 ```bash
 ecloud --version
 ```
+
 Pass: outputs `@layr-labs/ecloud-cli/<version>`.
 Fail: `npm install -g @layr-labs/ecloud-cli`
 
@@ -59,8 +60,10 @@ Fail: `npm install -g @layr-labs/ecloud-cli`
 ```bash
 ecloud auth whoami
 ```
+
 Pass: output contains `Address: 0x` and `Source: stored credentials`.
 Fail:
+
 - New user → `ecloud auth generate --store` (generates key, stores in OS keyring)
 - Has existing key → `ecloud auth login` (interactive prompt for private key)
 - CI/automation → set `ECLOUD_PRIVATE_KEY` env var instead of keyring
@@ -70,7 +73,9 @@ Fail:
 ```bash
 ecloud compute environment show
 ```
+
 Two environments exist:
+
 - `sepolia` — **Testnet (default).** Uses Sepolia ETH for gas. Deploy here first to test. Billing subscription flow is the same but uses test payment methods. All on-chain records are on Sepolia. Dashboard: `verify-sepolia.eigencloud.xyz`.
 - `mainnet-alpha` — **Production.** Uses real ETH for gas, real USDC for payments. Apps are publicly visible on the mainnet verify dashboard: `verify.eigencloud.xyz`. Use when the app is ready for real users and real funds.
 
@@ -84,8 +89,10 @@ Fix: `ecloud compute env set sepolia --yes` (or `mainnet-alpha`).
 ```bash
 ecloud billing status
 ```
+
 Pass: output contains `Status: ✓ Active`.
 Fail:
+
 1. `ecloud billing subscribe` — creates the subscription
 2. `ecloud billing top-up --amount 50` — purchases USDC credits
 
@@ -94,6 +101,7 @@ Fail:
 ```bash
 docker version --format '{{.Client.Version}}'
 ```
+
 Pass: outputs a version string.
 Fail: install Docker Desktop or Docker Engine.
 
@@ -108,23 +116,29 @@ uname -m
 ```
 
 **If `arm64` (Apple Silicon — most common dev machine):**
+
 ```bash
 docker buildx build --platform linux/amd64 -t <registry>/<image>:<tag> --push .
 ```
+
 This cross-compiles AND pushes in one step. The `--push` flag is required because buildx cross-compiled images can't be loaded into the local daemon.
 
 **If `x86_64` (native):**
+
 ```bash
 docker build -t <registry>/<image>:<tag> . && docker push <registry>/<image>:<tag>
 ```
 
 **After push, verify architecture:**
+
 ```bash
 docker manifest inspect <registry>/<image>:<tag> 2>&1 | grep architecture
 ```
+
 Must contain `amd64`. If it shows `arm64`, the image will crash in the TEE.
 
 **Image requirements:**
+
 - Must be in a **public** registry (Docker Hub, GHCR, etc.) — the TEE pulls at deploy time
 - Must be OCI-compliant
 - App should bind to `0.0.0.0` on its listening port (not `127.0.0.1`)
@@ -135,14 +149,14 @@ Must contain `amd64`. If it shows `arm64`, the image will crash in the TEE.
 
 ### Instance types
 
-| Instance Type | TEE | Approx $/hr |
-|--------------|-----|-------------|
-| `g1-micro-1v` | vTPM | ~$0.03 |
-| `g1-standard-2s` | — | ~$0.04 |
-| `g1-standard-2t` | Intel TDX | ~$0.07 |
-| `g1-standard-4s` | — | ~$0.12 |
-| `g1-standard-4t` | Intel TDX | ~$0.33 |
-| `g1-standard-8t` | Intel TDX | ~$0.66 |
+| Instance Type    | TEE       | Approx $/hr |
+| ---------------- | --------- | ----------- |
+| `g1-micro-1v`    | vTPM      | ~$0.03      |
+| `g1-standard-2s` | —         | ~$0.04      |
+| `g1-standard-2t` | Intel TDX | ~$0.07      |
+| `g1-standard-4s` | —         | ~$0.12      |
+| `g1-standard-4t` | Intel TDX | ~$0.33      |
+| `g1-standard-8t` | Intel TDX | ~$0.66      |
 
 Suffix convention (inferred, not officially documented): `t` = Intel TDX, `s` = likely AMD SEV, `v` = vTPM. Only TDX is confirmed in official EigenCloud docs. Prices are approximate — sourced from billing line items and may change.
 
@@ -192,12 +206,15 @@ ecloud compute build submit \
 This blocks and streams build logs by default. Use `--no-follow` to exit immediately after submission.
 
 If `--no-follow` was used, poll for completion:
+
 ```bash
 ecloud compute build status <build-id> --json
 ```
+
 On build failure: `ecloud compute build logs <build-id> --tail 50`
 
 Then deploy with the verifiable flag:
+
 ```bash
 ecloud compute app deploy \
   --name <app-name> \
@@ -211,41 +228,57 @@ ecloud compute app deploy \
 ```
 
 Additional flags for complex builds:
+
 - Multi-stage with dependencies: `--build-dependencies sha256:...`
 - TLS via Caddy: `--build-caddyfile Caddyfile`
 
 ### Deploy output parsing
 
-| stdout/stderr contains | Meaning | Next step |
-|------------------------|---------|-----------|
-| `0x` + 40 hex chars + dashboard URL | Success — deploy initiated | Save app ID → Gate 3 |
-| `subscription not active` | No billing subscription | `ecloud billing subscribe` → retry |
-| `insufficient credits` | USDC balance too low | `ecloud billing top-up --amount <N>` → retry |
-| Image pull error | Image not public, wrong arch, or bad ref | Verify with `docker manifest inspect` → retry |
-| `already exists` | App name collision | Change `--name` or use `upgrade` on existing app |
+| stdout/stderr contains              | Meaning                                  | Next step                                        |
+| ----------------------------------- | ---------------------------------------- | ------------------------------------------------ |
+| `0x` + 40 hex chars + dashboard URL | Success — deploy initiated               | Save app ID → Gate 3                             |
+| `subscription not active`           | No billing subscription                  | `ecloud billing subscribe` → retry               |
+| `insufficient credits`              | USDC balance too low                     | `ecloud billing top-up --amount <N>` → retry     |
+| Image pull error                    | Image not public, wrong arch, or bad ref | Verify with `docker manifest inspect` → retry    |
+| `already exists`                    | App name collision                       | Change `--name` or use `upgrade` on existing app |
 
 ---
 
 ## Gate 3: Verify deployment
 
-Deploy returns before the app is fully running. You must poll.
+Deploy returns before the app is fully running. Wait for it to settle.
 
-### Poll for running status
+### Wait for running status
+
+**Use `app status --wait` — do NOT tight-loop `app info`.** A bare
+`ecloud compute app info <app-id>` is a one-shot fetch with no pacing; calling
+it in a shell loop (or a hardcoded `sleep`) hammers the API and trips server
+rate limits. `status --wait` blocks using the CLI's internal watch loop, which
+paces requests and backs off on `429/502/503/504`.
 
 ```bash
-ecloud compute app info <app-id>
+# Blocks until the app reaches a terminal status or the timeout elapses.
+ecloud compute app status <app-id> --wait
+
+# Bound the wait (default 600s) and/or get machine-readable output:
+ECLOUD_WATCH_TIMEOUT_SECONDS=180 ecloud compute app status <app-id> --wait
+ecloud compute app status <app-id> --json   # one-shot: {"appId","status"}
 ```
 
-Parse these fields from output:
+`--json` emits `{"appId":"0x...","status":"Running"}`. Status is one of:
+`Running`, `Deploying`, `Stopped`, `Terminated`, `Failed`, `Unknown`.
 
-- **`Status:`** — one of: `Running`, `Deploying`, `Stopped`, `Terminated`, `Error`
+- If `status --wait` returns `Running` → proceed to health check.
+- If it times out (prints a recovery hint) → check `ecloud compute app info <app-id>`
+  once for details and `ecloud compute app logs <app-id>`.
+- If `Failed` → check logs: `ecloud compute app logs <app-id>`
+
+Use `app info <app-id>` (one-shot, not in a loop) only when you need richer
+details — IP, EVM/Solana addresses, release info:
+
 - **`IP:`** — public IP address (direct, no load balancer)
 - **`EVM Address:`** — TEE-derived EVM wallet (deterministic per app ID)
 - **`Solana Address:`** — TEE-derived Solana wallet (deterministic per app ID)
-
-If `Deploying` → wait 15 seconds, poll again. Typical time to `Running`: 1-3 minutes.
-If `Running` → proceed to health check.
-If `Error` → check logs: `ecloud compute app logs <app-id>`
 
 ### Health check
 
@@ -255,11 +288,11 @@ The app's listening port is exposed directly on the public IP. Check whichever p
 curl -s -o /dev/null -w "%{http_code}" http://<IP>:<APP_PORT>/
 ```
 
-| Response | Meaning |
-|----------|---------|
-| `200` | App is healthy and serving |
-| `404` | App is running but has no route at `/` — check your app's routes |
-| `000` | Connection refused — app not ready yet, wrong port, or app crashed on startup |
+| Response | Meaning                                                                       |
+| -------- | ----------------------------------------------------------------------------- |
+| `200`    | App is healthy and serving                                                    |
+| `404`    | App is running but has no route at `/` — check your app's routes              |
+| `000`    | Connection refused — app not ready yet, wrong port, or app crashed on startup |
 
 ### Verify provenance (verifiable builds only)
 
@@ -289,6 +322,7 @@ ecloud compute app profile set <app-id> \
 **Constraints:** Profile name cannot contain spaces. Use hyphens or camelCase (e.g., `CitiBike-MPP` not `Citi Bike MPP`).
 
 Dashboard URLs:
+
 - Sepolia: `https://verify-sepolia.eigencloud.xyz/app/<app-id>`
 - Mainnet: `https://verify.eigencloud.xyz/app/<app-id>`
 
@@ -305,6 +339,7 @@ ecloud compute app upgrade <app-id> \
 ```
 
 The repo must be public. After upgrade, verify provenance:
+
 ```bash
 ecloud compute app releases <app-id> --full
 ecloud compute build verify <image-digest-or-commit> --json
@@ -322,6 +357,7 @@ ecloud compute app upgrade <app-id> \
 ```
 
 For verifiable upgrade:
+
 ```bash
 ecloud compute app upgrade <app-id> \
   --verifiable \
@@ -330,7 +366,7 @@ ecloud compute app upgrade <app-id> \
   --verbose
 ```
 
-After upgrade, re-run Gate 3 (poll `app info` until `Running`, then health check).
+After upgrade, re-run Gate 3 (`app status <app-id> --wait` until `Running`, then health check).
 
 App ID and derived keys persist across upgrades.
 
@@ -341,12 +377,15 @@ App ID and derived keys persist across upgrades.
 No native rollback command exists. Manual procedure:
 
 **1. Find previous release:**
+
 ```bash
 ecloud compute app releases <app-id> --json
 ```
+
 The `releases` array is ordered by creation time. Previous release = second-to-last entry. Extract `registryUrl` and `imageDigest`.
 
 **2. Upgrade to previous image:**
+
 ```bash
 ecloud compute app upgrade <app-id> \
   --image-ref <registryUrl>@<imageDigest> \
@@ -356,10 +395,12 @@ ecloud compute app upgrade <app-id> \
 **3. Verify:** re-run Gate 3.
 
 **If upgrade fails (app stuck or crashed):**
+
 ```bash
 ecloud compute app terminate <app-id> --force
 ecloud compute app deploy --name <name> --image-ref <old-image> --instance-type <type> --verbose
 ```
+
 This creates a new app ID. Derived keys will be different. Only do this as a last resort.
 
 ---
@@ -381,21 +422,21 @@ ecloud compute app info <app-id> --address-count 5  # show more derived addresse
 
 ## Error recovery
 
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `App name 'X' not found` | Name lookup is profile-based, unreliable | Use hex app ID (0x...) |
-| `subscription not active` | No billing subscription | `ecloud billing subscribe` |
-| `insufficient credits` | USDC balance depleted | `ecloud billing top-up --amount <N>` |
-| Image pull failure | Image not public or wrong architecture | `docker manifest inspect <ref>` — verify `linux/amd64` |
-| App crashes immediately after deploy | arm64 image deployed to TDX instance | Rebuild with `docker buildx build --platform linux/amd64` |
-| `No builds found` on verify | Image was pushed directly, not via verifiable build | Redeploy with `--verifiable --repo <url> --commit <sha>` |
-| Status stuck on `Deploying` | Large image or infrastructure delay | `ecloud compute app logs <app-id>` for diagnostics |
-| Auth errors | Key not in keyring or expired | `ecloud auth whoami` to diagnose → `ecloud auth login` to fix |
-| Wrong environment | Deployed to sepolia instead of mainnet (or vice versa) | `ecloud compute env show` → `ecloud compute env set <env> --yes` |
-| Logs return 425 error | Normal during provisioning (1-2+ min after deploy) | Wait and retry, or use `--watch` to stream when available |
-| App shows "(unnamed)" on dashboard | `--name` only sets CLI name, not dashboard profile | `ecloud compute app profile set <app-id> --name "Name"` |
-| Profile name rejected | Spaces not allowed in profile names | Use hyphens or camelCase |
-| Mainnet app unreachable despite "Running" status | Mainnet networking can take 5+ min after deploy (longer than sepolia) | Keep polling — sepolia ~30s, mainnet can be several minutes |
+| Error                                            | Cause                                                                 | Fix                                                              |
+| ------------------------------------------------ | --------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `App name 'X' not found`                         | Name lookup is profile-based, unreliable                              | Use hex app ID (0x...)                                           |
+| `subscription not active`                        | No billing subscription                                               | `ecloud billing subscribe`                                       |
+| `insufficient credits`                           | USDC balance depleted                                                 | `ecloud billing top-up --amount <N>`                             |
+| Image pull failure                               | Image not public or wrong architecture                                | `docker manifest inspect <ref>` — verify `linux/amd64`           |
+| App crashes immediately after deploy             | arm64 image deployed to TDX instance                                  | Rebuild with `docker buildx build --platform linux/amd64`        |
+| `No builds found` on verify                      | Image was pushed directly, not via verifiable build                   | Redeploy with `--verifiable --repo <url> --commit <sha>`         |
+| Status stuck on `Deploying`                      | Large image or infrastructure delay                                   | `ecloud compute app logs <app-id>` for diagnostics               |
+| Auth errors                                      | Key not in keyring or expired                                         | `ecloud auth whoami` to diagnose → `ecloud auth login` to fix    |
+| Wrong environment                                | Deployed to sepolia instead of mainnet (or vice versa)                | `ecloud compute env show` → `ecloud compute env set <env> --yes` |
+| Logs return 425 error                            | Normal during provisioning (1-2+ min after deploy)                    | Wait and retry, or use `--watch` to stream when available        |
+| App shows "(unnamed)" on dashboard               | `--name` only sets CLI name, not dashboard profile                    | `ecloud compute app profile set <app-id> --name "Name"`          |
+| Profile name rejected                            | Spaces not allowed in profile names                                   | Use hyphens or camelCase                                         |
+| Mainnet app unreachable despite "Running" status | Mainnet networking can take 5+ min after deploy (longer than sepolia) | Keep polling — sepolia ~30s, mainnet can be several minutes      |
 
 ---
 

--- a/packages/cli/skills/deploy/SKILL.md
+++ b/packages/cli/skills/deploy/SKILL.md
@@ -22,7 +22,11 @@ You are deploying to EigenCloud TEE (Trusted Execution Environment) infrastructu
 
 2. **Always use hex app IDs (0x...), never display names.** Name lookup is profile-based and silently fails on some commands (confirmed: `app info` by name returns `not found` while the same app works fine by ID).
 
-3. **The CLI returns exit 1 for all errors.** There are no granular exit codes. Parse stdout/stderr content to determine what went wrong.
+3. **Exit codes.** Most commands return exit `1` for any error (parse stdout/stderr to see what went wrong). **`app deploy` and `app upgrade` are the exception** — they emit distinct codes so you can branch without parsing text:
+   - `2` — invalid/missing input; failed **before** any build. Fix flags and re-run.
+   - `3` — build/push failed; **no on-chain transaction was attempted**. No image was produced.
+   - `4` — build/push succeeded but the **on-chain transaction failed**. The image is already built and pushed; re-running deploy/upgrade reuses it (you are not paying for another ~7-min build).
+   - `1` — generic/unclassified error.
 
 4. **Env vars are encrypted client-side** before transmission. They are only decrypted inside the TEE. Never visible in logs or API responses.
 

--- a/packages/cli/src/__tests__/flags.test.ts
+++ b/packages/cli/src/__tests__/flags.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the two inputs the environment default depends on.
+vi.mock("@layr-labs/ecloud-sdk", () => ({
+  getBuildType: vi.fn(),
+}));
+vi.mock("../utils/globalConfig", () => ({
+  getDefaultEnvironment: vi.fn(),
+}));
+
+import { commonFlags } from "../flags";
+import { getBuildType } from "@layr-labs/ecloud-sdk";
+import { getDefaultEnvironment } from "../utils/globalConfig";
+
+/**
+ * RND-589: prod builds default --environment to mainnet-alpha (was sepolia);
+ * dev builds stay sepolia-dev; an explicit configured default always wins.
+ * The default is an async thunk on the oclif flag definition.
+ */
+describe("commonFlags.environment default (RND-589)", () => {
+  // oclif stores the default function on the flag's `default` property.
+  const resolveDefault = () =>
+    (commonFlags.environment as unknown as { default: () => Promise<string> }).default();
+
+  afterEach(() => vi.clearAllMocks());
+
+  it("defaults to mainnet-alpha on prod builds with no configured default", async () => {
+    (getDefaultEnvironment as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    (getBuildType as ReturnType<typeof vi.fn>).mockReturnValue("prod");
+    await expect(resolveDefault()).resolves.toBe("mainnet-alpha");
+  });
+
+  it("defaults to sepolia-dev on dev builds", async () => {
+    (getDefaultEnvironment as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    (getBuildType as ReturnType<typeof vi.fn>).mockReturnValue("dev");
+    await expect(resolveDefault()).resolves.toBe("sepolia-dev");
+  });
+
+  it("honors a configured default over the build-type fallback", async () => {
+    (getDefaultEnvironment as ReturnType<typeof vi.fn>).mockReturnValue("sepolia");
+    (getBuildType as ReturnType<typeof vi.fn>).mockReturnValue("prod");
+    await expect(resolveDefault()).resolves.toBe("sepolia");
+  });
+});

--- a/packages/cli/src/__tests__/flags.test.ts
+++ b/packages/cli/src/__tests__/flags.test.ts
@@ -13,11 +13,11 @@ import { getBuildType } from "@layr-labs/ecloud-sdk";
 import { getDefaultEnvironment } from "../utils/globalConfig";
 
 /**
- * RND-589: prod builds default --environment to mainnet-alpha (was sepolia);
+ * Prod builds default --environment to mainnet-alpha (was sepolia);
  * dev builds stay sepolia-dev; an explicit configured default always wins.
  * The default is an async thunk on the oclif flag definition.
  */
-describe("commonFlags.environment default (RND-589)", () => {
+describe("commonFlags.environment default", () => {
   // oclif stores the default function on the flag's `default` property.
   const resolveDefault = () =>
     (commonFlags.environment as unknown as { default: () => Promise<string> }).default();

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -5,13 +5,27 @@ import {
   createAdminModule,
   getEnvironmentConfig,
   requirePrivateKey,
+  type Logger,
 } from "@layr-labs/ecloud-sdk";
 import { CommonFlags, validateCommonFlags } from "./flags";
 import { getClientId } from "./utils/version";
 import { createViemClients } from "./utils/viemClients";
 import { Hex } from "viem";
 
-export async function createComputeClient(flags: CommonFlags) {
+/** Options for {@link createComputeClient}. */
+export interface CreateComputeClientOptions {
+  /**
+   * Logger override forwarded to the SDK compute module. Commands emitting
+   * machine-readable output (`--json`) pass a stderr-routed logger so SDK
+   * progress messages never corrupt stdout.
+   */
+  logger?: Logger;
+}
+
+export async function createComputeClient(
+  flags: CommonFlags,
+  options: CreateComputeClientOptions = {},
+) {
   flags = await validateCommonFlags(flags);
 
   const environment = flags.environment;
@@ -39,6 +53,7 @@ export async function createComputeClient(flags: CommonFlags) {
     environment,
     clientId: getClientId(),
     skipTelemetry: true, // CLI already has telemetry, skip SDK telemetry
+    logger: options.logger,
   });
 }
 

--- a/packages/cli/src/commands/billing/__tests__/status.test.ts
+++ b/packages/cli/src/commands/billing/__tests__/status.test.ts
@@ -8,7 +8,16 @@ vi.mock("../../../telemetry", () => ({
   withTelemetry: vi.fn((_cmd: unknown, fn: () => Promise<void>) => fn()),
 }));
 
+vi.mock("@layr-labs/ecloud-sdk", () => ({
+  getEnvironmentConfig: vi.fn(() => ({ defaultRPCURL: "https://rpc.example" })),
+}));
+
+vi.mock("../../../utils/viemClients", () => ({
+  createViemClients: vi.fn(),
+}));
+
 import { createBillingClient } from "../../../client";
+import { createViemClients } from "../../../utils/viemClients";
 
 describe("ecloud billing status — top-up hint", () => {
   let logOutput: string[];
@@ -19,6 +28,7 @@ describe("ecloud billing status — top-up hint", () => {
 
   beforeEach(() => {
     logOutput = [];
+    warnOutput = [];
     mockBilling = {
       address: "0xabcdef1234567890abcdef1234567890abcdef12",
       getStatus: vi.fn(),
@@ -26,15 +36,24 @@ describe("ecloud billing status — top-up hint", () => {
     (createBillingClient as ReturnType<typeof vi.fn>).mockResolvedValue(mockBilling);
   });
 
-  async function runStatusCommand(statusResult: Record<string, unknown>) {
+  let warnOutput: string[];
+
+  async function runStatusCommand(
+    statusResult: Record<string, unknown>,
+    flagOverrides: Record<string, unknown> = {},
+  ) {
     const { default: BillingStatus } = await import("../status");
     mockBilling.getStatus.mockResolvedValue(statusResult);
 
     const cmd = new BillingStatus([], {} as any);
     cmd.parse = vi.fn().mockResolvedValue({
-      flags: { product: "compute", verbose: false },
+      flags: { product: "compute", verbose: false, ...flagOverrides },
     });
     cmd.log = vi.fn((...args: string[]) => logOutput.push(args.join(" ")));
+    cmd.warn = vi.fn((msg: string | Error) => {
+      warnOutput.push(typeof msg === "string" ? msg : msg.message);
+      return msg as string & Error;
+    });
     cmd.debug = vi.fn();
 
     await cmd.run();
@@ -83,5 +102,39 @@ describe("ecloud billing status — top-up hint", () => {
     const fullOutput = output.join("\n");
 
     expect(fullOutput).not.toContain("Need more credits?");
+  });
+
+  describe("wallet ETH balance line", () => {
+    it("warns (does not silently swallow) when the balance read fails, but still completes", async () => {
+      (createViemClients as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("invalid private key");
+      });
+
+      const output = await runStatusCommand(
+        { subscriptionStatus: "active", productId: "compute" },
+        { "private-key": "0xbad", environment: "sepolia" },
+      );
+
+      // The command still finishes and prints the rest of the status.
+      expect(output.join("\n")).toContain("Subscription Status:");
+      // The failure reason is surfaced, not discarded.
+      expect(warnOutput.join("\n")).toMatch(/wallet ETH|balance/i);
+      expect(warnOutput.join("\n")).toContain("invalid private key");
+    });
+
+    it("prints the ETH line on a successful balance read", async () => {
+      (createViemClients as ReturnType<typeof vi.fn>).mockReturnValue({
+        publicClient: { getBalance: vi.fn().mockResolvedValue(1000000000000000000n) },
+        address: "0xabcdef1234567890abcdef1234567890abcdef12",
+      });
+
+      const output = await runStatusCommand(
+        { subscriptionStatus: "active", productId: "compute" },
+        { "private-key": "0xgood", environment: "sepolia" },
+      );
+
+      expect(output.join("\n")).toMatch(/Wallet ETH.*1 ETH/);
+      expect(warnOutput).toHaveLength(0);
+    });
   });
 });

--- a/packages/cli/src/commands/billing/cancel.ts
+++ b/packages/cli/src/commands/billing/cancel.ts
@@ -10,8 +10,7 @@ export default class BillingCancel extends Command {
   static description = "Cancel subscription";
 
   static flags = {
-    "private-key": commonFlags["private-key"],
-    verbose: commonFlags.verbose,
+    ...commonFlags,
     product: Flags.string({
       required: false,
       description: "Product ID",

--- a/packages/cli/src/commands/billing/status.ts
+++ b/packages/cli/src/commands/billing/status.ts
@@ -1,6 +1,9 @@
 import { Command, Flags } from "@oclif/core";
 import { createBillingClient } from "../../client";
 import { commonFlags } from "../../flags";
+import { getEnvironmentConfig } from "@layr-labs/ecloud-sdk";
+import { createViemClients } from "../../utils/viemClients";
+import { formatEther } from "viem";
 import chalk from "chalk";
 import { withTelemetry } from "../../telemetry";
 
@@ -58,6 +61,29 @@ export default class BillingStatus extends Command {
 
       this.log(`\n${chalk.bold("Subscription Status:")}`);
       this.log(`  Wallet: ${billing.address}`);
+
+      // Show the wallet's on-chain ETH so the credit-vs-gas gap is visible
+      // before a deploy: compute credits do NOT pay on-chain gas (RND-596).
+      // Best-effort — never fail `billing status` if the balance read fails.
+      try {
+        const privateKey = flags["private-key"];
+        if (privateKey) {
+          const environment = flags.environment;
+          const environmentConfig = getEnvironmentConfig(environment);
+          const rpcUrl = flags["rpc-url"] || environmentConfig.defaultRPCURL;
+          const { publicClient, address } = createViemClients({ privateKey, rpcUrl, environment });
+          const balanceWei = await publicClient.getBalance({ address });
+          const eth = formatEther(balanceWei);
+          const note =
+            balanceWei === BigInt(0)
+              ? chalk.yellow("  (fund with ETH to pay deploy/upgrade gas)")
+              : "";
+          this.log(`  Wallet ETH (${environment}): ${chalk.cyan(`${eth} ETH`)}${note}`);
+        }
+      } catch {
+        // ignore — ETH balance is informational
+      }
+
       this.log(`  Status: ${formatStatus(result.subscriptionStatus)}`);
       this.log(`  Product: ${result.productId}`);
 
@@ -75,7 +101,9 @@ export default class BillingStatus extends Command {
           const product = `${flags.product.charAt(0).toUpperCase()}${flags.product.slice(1)}`;
           const isChainSpecific = item.description.match(/\b(sepolia|mainnet)\b/i);
           if (isChainSpecific) {
-            const chain = item.description.toLowerCase().includes("sepolia") ? "Sepolia" : "Mainnet";
+            const chain = item.description.toLowerCase().includes("sepolia")
+              ? "Sepolia"
+              : "Mainnet";
             this.log(
               `    • ${product} (${chain}): $${item.subtotal.toFixed(2)} (${item.quantity} vCPU hours × $${item.price.toFixed(3)}/vCPU hour)`,
             );

--- a/packages/cli/src/commands/billing/status.ts
+++ b/packages/cli/src/commands/billing/status.ts
@@ -3,6 +3,7 @@ import { createBillingClient } from "../../client";
 import { commonFlags } from "../../flags";
 import { getEnvironmentConfig } from "@layr-labs/ecloud-sdk";
 import { createViemClients } from "../../utils/viemClients";
+import { errorMessage } from "../../utils/exitCodes";
 import { formatEther } from "viem";
 import chalk from "chalk";
 import { withTelemetry } from "../../telemetry";
@@ -80,8 +81,12 @@ export default class BillingStatus extends Command {
               : "";
           this.log(`  Wallet ETH (${environment}): ${chalk.cyan(`${eth} ETH`)}${note}`);
         }
-      } catch {
-        // ignore — ETH balance is informational
+      } catch (err) {
+        // Best-effort: the ETH line is informational, so a failure here must
+        // not abort `billing status`. But surface the reason rather than
+        // swallowing it — a malformed --private-key or an unreachable RPC is
+        // worth telling the user about.
+        this.warn(`Could not read wallet ETH balance: ${errorMessage(err)}`);
       }
 
       this.log(`  Status: ${formatStatus(result.subscriptionStatus)}`);

--- a/packages/cli/src/commands/billing/status.ts
+++ b/packages/cli/src/commands/billing/status.ts
@@ -63,7 +63,7 @@ export default class BillingStatus extends Command {
       this.log(`  Wallet: ${billing.address}`);
 
       // Show the wallet's on-chain ETH so the credit-vs-gas gap is visible
-      // before a deploy: compute credits do NOT pay on-chain gas (RND-596).
+      // before a deploy: compute credits do NOT pay on-chain gas.
       // Best-effort — never fail `billing status` if the balance read fails.
       try {
         const privateKey = flags["private-key"];

--- a/packages/cli/src/commands/compute/app/__tests__/status.test.ts
+++ b/packages/cli/src/commands/compute/app/__tests__/status.test.ts
@@ -30,7 +30,7 @@ vi.mock("../../../../client", () => ({
   createComputeClient: vi.fn(async () => ({ app: { watchDeployment } })),
 }));
 
-describe("compute app status (RND-592)", () => {
+describe("compute app status", () => {
   let logOutput: string[];
 
   beforeEach(() => {

--- a/packages/cli/src/commands/compute/app/__tests__/status.test.ts
+++ b/packages/cli/src/commands/compute/app/__tests__/status.test.ts
@@ -26,8 +26,9 @@ vi.mock("../../../../utils/viemClients", () => ({
   createViemClients: vi.fn(() => ({ publicClient: {}, walletClient: {} })),
 }));
 const watchDeployment = vi.fn();
+const createComputeClient = vi.fn(async () => ({ app: { watchDeployment } }));
 vi.mock("../../../../client", () => ({
-  createComputeClient: vi.fn(async () => ({ app: { watchDeployment } })),
+  createComputeClient: (...args: unknown[]) => createComputeClient(...(args as [])),
 }));
 
 describe("compute app status", () => {
@@ -68,11 +69,55 @@ describe("compute app status", () => {
     expect(JSON.parse(out[0])).toEqual({ appId: APP, status: "Unknown" });
   });
 
-  it("--wait blocks via watchDeployment, then does a final status read", async () => {
+  it("--wait blocks via watchDeployment for transitional statuses, then does a final status read", async () => {
+    // Initial read: still deploying -> should wait. Final read: settled.
+    getStatuses
+      .mockResolvedValueOnce([{ address: APP, status: "Deploying" }])
+      .mockResolvedValueOnce([{ address: APP, status: "Running" }]);
     watchDeployment.mockResolvedValue(undefined);
-    getStatuses.mockResolvedValue([{ address: APP, status: "Running" }]);
     const out = await runCommand({ wait: true, json: true, "watch-timeout": 30 });
     expect(watchDeployment).toHaveBeenCalledWith(APP, { timeoutSeconds: 30 });
+    expect(JSON.parse(out[0])).toEqual({ appId: APP, status: "Running" });
+  });
+
+  it("--wait returns immediately for Running without watching", async () => {
+    getStatuses.mockResolvedValue([{ address: APP, status: "Running" }]);
+    const out = await runCommand({ wait: true, json: false });
+    expect(watchDeployment).not.toHaveBeenCalled();
+    expect(out.join("\n")).toContain("Running");
+  });
+
+  it("--wait returns immediately for Terminated without watching", async () => {
+    getStatuses.mockResolvedValue([{ address: APP, status: "Terminated" }]);
+    const out = await runCommand({ wait: true, json: true });
+    expect(watchDeployment).not.toHaveBeenCalled();
+    expect(JSON.parse(out[0])).toEqual({ appId: APP, status: "Terminated" });
+  });
+
+  it("--wait returns immediately for Stopped without watching", async () => {
+    getStatuses.mockResolvedValue([{ address: APP, status: "Stopped" }]);
+    const out = await runCommand({ wait: true, json: true });
+    expect(watchDeployment).not.toHaveBeenCalled();
+    expect(JSON.parse(out[0])).toEqual({ appId: APP, status: "Stopped" });
+  });
+
+  it("--wait --json keeps stdout pure JSON by routing SDK progress off stdout", async () => {
+    // Transitional initial status forces a watch; the SDK progress logger
+    // must not be allowed to write to stdout or it corrupts the JSON.
+    getStatuses
+      .mockResolvedValueOnce([{ address: APP, status: "Deploying" }])
+      .mockResolvedValueOnce([{ address: APP, status: "Running" }]);
+    watchDeployment.mockResolvedValue(undefined);
+
+    const out = await runCommand({ wait: true, json: true, "watch-timeout": 30 });
+
+    // The compute client must be built with a logger override so the SDK
+    // does not print "Waiting for app to start..." / "Status: ..." to stdout.
+    const clientOpts = createComputeClient.mock.calls[0]?.[1] as { logger?: unknown } | undefined;
+    expect(clientOpts?.logger).toBeDefined();
+
+    // stdout is exactly one line, and that line is the JSON object.
+    expect(out).toHaveLength(1);
     expect(JSON.parse(out[0])).toEqual({ appId: APP, status: "Running" });
   });
 });

--- a/packages/cli/src/commands/compute/app/__tests__/status.test.ts
+++ b/packages/cli/src/commands/compute/app/__tests__/status.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const APP = "0x01d3e5851c5F361b4E4988fd3cCc503a6D7b5c09";
+
+const getStatuses = vi.fn();
+vi.mock("@layr-labs/ecloud-sdk", () => ({
+  getEnvironmentConfig: vi.fn(() => ({ defaultRPCURL: "https://rpc.test" })),
+  UserApiClient: class {
+    getStatuses = getStatuses;
+  },
+  WatchTimeoutError: class WatchTimeoutError extends Error {},
+}));
+vi.mock("../../../../flags", () => ({
+  commonFlags: {},
+  validateCommonFlags: vi.fn(async (f: Record<string, unknown>) => ({
+    ...f,
+    environment: "sepolia-dev",
+    "private-key": "0xkey",
+  })),
+}));
+vi.mock("../../../../utils/prompts", () => ({
+  getOrPromptAppID: vi.fn(async () => APP),
+}));
+vi.mock("../../../../utils/version", () => ({ getClientId: vi.fn(() => "test") }));
+vi.mock("../../../../utils/viemClients", () => ({
+  createViemClients: vi.fn(() => ({ publicClient: {}, walletClient: {} })),
+}));
+const watchDeployment = vi.fn();
+vi.mock("../../../../client", () => ({
+  createComputeClient: vi.fn(async () => ({ app: { watchDeployment } })),
+}));
+
+describe("compute app status (RND-592)", () => {
+  let logOutput: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logOutput = [];
+  });
+
+  async function runCommand(flags: Record<string, unknown>) {
+    const { default: AppStatus } = await import("../status");
+    const cmd = new AppStatus([], {} as any);
+    cmd.parse = vi.fn().mockResolvedValue({ args: { "app-id": APP }, flags });
+    cmd.log = vi.fn((...a: string[]) => logOutput.push(a.join(" ")));
+    cmd.warn = vi.fn() as any;
+    await cmd.run();
+    return logOutput;
+  }
+
+  it("prints the one-shot status from getStatuses", async () => {
+    getStatuses.mockResolvedValue([{ address: APP, status: "Running" }]);
+    const out = await runCommand({ wait: false, json: false });
+    expect(getStatuses).toHaveBeenCalledWith([APP]);
+    expect(watchDeployment).not.toHaveBeenCalled();
+    expect(out.join("\n")).toContain("Running");
+  });
+
+  it("emits machine-readable JSON with --json", async () => {
+    getStatuses.mockResolvedValue([{ address: APP, status: "Terminated" }]);
+    const out = await runCommand({ wait: false, json: true });
+    expect(JSON.parse(out[0])).toEqual({ appId: APP, status: "Terminated" });
+  });
+
+  it("falls back to Unknown when the API returns nothing", async () => {
+    getStatuses.mockResolvedValue([]);
+    const out = await runCommand({ wait: false, json: true });
+    expect(JSON.parse(out[0])).toEqual({ appId: APP, status: "Unknown" });
+  });
+
+  it("--wait blocks via watchDeployment, then does a final status read", async () => {
+    watchDeployment.mockResolvedValue(undefined);
+    getStatuses.mockResolvedValue([{ address: APP, status: "Running" }]);
+    const out = await runCommand({ wait: true, json: true, "watch-timeout": 30 });
+    expect(watchDeployment).toHaveBeenCalledWith(APP, { timeoutSeconds: 30 });
+    expect(JSON.parse(out[0])).toEqual({ appId: APP, status: "Running" });
+  });
+});

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -170,9 +170,15 @@ export default class AppDeploy extends Command {
     return withTelemetry(this, async () => {
       const { flags } = await this.parse(AppDeploy);
 
+      // Resolve the interactivity decision once (flag › CI › !TTY) and thread it
+      // into the optional-input helpers. They take it as a parameter rather than
+      // re-deriving from process internally, so --non-interactive is honored
+      // even on a TTY and the helpers stay pure/testable.
+      const nonInteractive = isNonInteractive(flags);
+
       // Non-interactive: report every missing required input at once instead of
       // failing one prompt at a time.
-      if (isNonInteractive(flags)) {
+      if (nonInteractive) {
         const missing = collectMissingRequiredInputs(
           {
             imageRef: flags["image-ref"],
@@ -322,7 +328,7 @@ export default class AppDeploy extends Command {
           : await promptVerifiableGitSourceInputs();
 
         // Prompt for env file after git inputs
-        envFilePath = await getEnvFileInteractive(flags["env-file"]);
+        envFilePath = await getEnvFileInteractive(flags["env-file"], nonInteractive);
 
         const includeTlsCaddyfile = isTlsEnabledFromEnvFile(envFilePath);
         if (includeTlsCaddyfile && !inputs.caddyfilePath) {
@@ -409,7 +415,7 @@ export default class AppDeploy extends Command {
       const dockerfilePath =
         isVerifiable || deployExistingImageRef
           ? ""
-          : await getDockerfileInteractive(flags.dockerfile);
+          : await getDockerfileInteractive(flags.dockerfile, nonInteractive);
       const buildFromDockerfile = dockerfilePath !== "";
 
       // 2. Get image reference interactively (context-aware)
@@ -428,7 +434,7 @@ export default class AppDeploy extends Command {
       );
 
       // 4. Get env file path interactively
-      envFilePath = envFilePath ?? (await getEnvFileInteractive(flags["env-file"]));
+      envFilePath = envFilePath ?? (await getEnvFileInteractive(flags["env-file"], nonInteractive));
 
       // 4b. Merge inline --env KEY=VALUE vars (overrides env file values)
       if (flags.env && flags.env.length > 0) {
@@ -446,17 +452,19 @@ export default class AppDeploy extends Command {
         flags["instance-type"],
         "", // No pinned default for new deployments; non-interactive falls back to g1-standard-2s
         availableTypes,
-        isNonInteractive(flags),
+        nonInteractive,
       );
 
       // 6. Get log visibility interactively
       const logSettings = await getLogSettingsInteractive(
         flags["log-visibility"] as LogVisibility | undefined,
+        nonInteractive,
       );
 
       // 7. Get resource usage monitoring interactively
       const resourceUsageMonitoring = await getResourceUsageMonitoringInteractive(
         flags["resource-usage-monitoring"] as ResourceUsageMonitoring | undefined,
+        nonInteractive,
       );
 
       // 8. Prepare deployment (builds image, pushes to registry, prepares batch, estimates gas)

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -1,10 +1,5 @@
 import { Command, Flags } from "@oclif/core";
-import {
-  getEnvironmentConfig,
-  UserApiClient,
-  isMainnet,
-  WatchTimeoutError,
-} from "@layr-labs/ecloud-sdk";
+import { getEnvironmentConfig, isMainnet, WatchTimeoutError } from "@layr-labs/ecloud-sdk";
 import type { PrepareDeployResult, GasEstimate } from "@layr-labs/ecloud-sdk";
 import { withTelemetry } from "../../../telemetry";
 import { commonFlags, applyTxOverrides } from "../../../flags";
@@ -16,7 +11,6 @@ import {
   getOrPromptAppName,
   getEnvFile,
   getInstanceType,
-  type SkuInfo,
   getLogSettings,
   getResourceUsageMonitoring,
   getAppProfileInteractive,
@@ -32,7 +26,7 @@ import {
   collectMissingRequiredInputs,
 } from "../../../utils/prompts";
 import { invalidateProfileCache, setLinkedAppForDirectory } from "../../../utils/globalConfig";
-import { getClientId } from "../../../utils/version";
+import { fetchAvailableInstanceTypes } from "../../../utils/instanceTypes";
 import chalk from "chalk";
 import { createBuildClient } from "../../../client";
 import { formatVerifiableBuildSummary } from "../../../utils/build";
@@ -671,37 +665,5 @@ export default class AppDeploy extends Command {
         this.log(chalk.gray(`  curl -s -o /dev/null -w "%{http_code}" http://${ipAddress}/`));
       }
     });
-  }
-}
-
-/**
- * Fetch available instance types from backend
- */
-async function fetchAvailableInstanceTypes(
-  environment: string,
-  environmentConfig: any,
-  privateKey: string,
-  rpcUrl: string,
-): Promise<SkuInfo[]> {
-  try {
-    const { publicClient, walletClient } = createViemClients({
-      privateKey,
-      rpcUrl,
-      environment,
-    });
-    const userApiClient = new UserApiClient(environmentConfig, walletClient, publicClient, {
-      clientId: getClientId(),
-    });
-
-    const skuList = await userApiClient.getSKUs();
-    if (skuList.skus.length === 0) {
-      throw new Error("No instance types available from server");
-    }
-
-    return skuList.skus;
-  } catch (err: any) {
-    console.warn(`Failed to fetch instance types: ${err.message}`);
-    // Return a default fallback
-    return [{ sku: "g1-standard-4t", description: "4 vCPUs, 16 GB memory, TDX" }];
   }
 }

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -43,6 +43,7 @@ import {
 } from "../../../utils/dockerhub";
 import { isTlsEnabledFromEnvFile } from "../../../utils/tls";
 import { mergeInlineEnvVars } from "../../../utils/env";
+import { EXIT_CODES, errorMessage } from "../../../utils/exitCodes";
 import type { SubmitBuildRequest } from "@layr-labs/ecloud-sdk";
 
 export default class AppDeploy extends Command {
@@ -185,7 +186,7 @@ export default class AppDeploy extends Command {
         if (missing.length > 0) {
           this.error(
             `Missing required input(s) for non-interactive deploy:\n  - ${missing.join("\n  - ")}`,
-            { exit: 1 },
+            { exit: EXIT_CODES.INVALID_INPUT },
           );
         }
       }
@@ -470,28 +471,38 @@ export default class AppDeploy extends Command {
       // the normal prepareDeploy path so that layerRemoteImageIfNeeded can
       // add the ecloud runtime layer (startup script, KMS client, Caddy) if
       // the image doesn't already have it.
-      const { prepared, gasEstimate } =
-        verifiableMode === "git"
-          ? await compute.app.prepareDeployFromVerifiableBuild({
-              name: appName,
-              imageRef,
-              imageDigest: verifiableImageDigest!,
-              envFile: envFilePath,
-              instanceType,
-              logVisibility,
-              resourceUsageMonitoring,
-              billTo: "developer",
-            })
-          : await compute.app.prepareDeploy({
-              name: appName,
-              dockerfile: dockerfilePath,
-              imageRef,
-              envFile: envFilePath,
-              instanceType,
-              logVisibility,
-              resourceUsageMonitoring,
-              billTo: "developer",
-            });
+      // Build/push stage — failures here mean no image was produced and no
+      // on-chain tx was attempted. Distinct exit code so callers don't confuse
+      // it with an on-chain failure (RND-591).
+      let prepared, gasEstimate;
+      try {
+        ({ prepared, gasEstimate } =
+          verifiableMode === "git"
+            ? await compute.app.prepareDeployFromVerifiableBuild({
+                name: appName,
+                imageRef,
+                imageDigest: verifiableImageDigest!,
+                envFile: envFilePath,
+                instanceType,
+                logVisibility,
+                resourceUsageMonitoring,
+                billTo: "developer",
+              })
+            : await compute.app.prepareDeploy({
+                name: appName,
+                dockerfile: dockerfilePath,
+                imageRef,
+                envFile: envFilePath,
+                instanceType,
+                logVisibility,
+                resourceUsageMonitoring,
+                billTo: "developer",
+              }));
+      } catch (err) {
+        this.error(`Build/push failed (no deployment was attempted): ${errorMessage(err)}`, {
+          exit: EXIT_CODES.BUILD_FAILED,
+        });
+      }
 
       // 9. Apply gas overrides if provided, show estimate, and prompt for confirmation on mainnet
       const finalTx = await applyTxOverrides(gasEstimate, flags, { publicClient, address });
@@ -515,8 +526,19 @@ export default class AppDeploy extends Command {
         }
       }
 
-      // 10. Execute the deployment
-      const res = await compute.app.executeDeploy(prepared, finalTx);
+      // 10. Execute the deployment (on-chain stage). The image is already
+      // built+pushed at this point; a failure here is distinct from a build
+      // failure and a re-run will reuse the pushed image (RND-591).
+      let res;
+      try {
+        res = await compute.app.executeDeploy(prepared, finalTx);
+      } catch (err) {
+        this.error(
+          `On-chain deployment failed after the image was built and pushed: ${errorMessage(err)}\n` +
+            `The image is already pushed — re-running deploy will reuse it.`,
+          { exit: EXIT_CODES.ONCHAIN_FAILED },
+        );
+      }
 
       // 11. Collect app profile while deployment is in progress (optional)
       if (!flags["skip-profile"]) {

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -11,14 +11,14 @@ import { commonFlags, applyTxOverrides } from "../../../flags";
 import { createComputeClient } from "../../../client";
 import { createViemClients } from "../../../utils/viemClients";
 import {
-  getDockerfileInteractive,
+  getDockerfile,
   getImageReferenceInteractive,
   getOrPromptAppName,
-  getEnvFileInteractive,
-  getInstanceTypeInteractive,
+  getEnvFile,
+  getInstanceType,
   type SkuInfo,
-  getLogSettingsInteractive,
-  getResourceUsageMonitoringInteractive,
+  getLogSettings,
+  getResourceUsageMonitoring,
   getAppProfileInteractive,
   LogVisibility,
   ResourceUsageMonitoring,
@@ -328,7 +328,7 @@ export default class AppDeploy extends Command {
           : await promptVerifiableGitSourceInputs();
 
         // Prompt for env file after git inputs
-        envFilePath = await getEnvFileInteractive(flags["env-file"], nonInteractive);
+        envFilePath = await getEnvFile(flags["env-file"], nonInteractive);
 
         const includeTlsCaddyfile = isTlsEnabledFromEnvFile(envFilePath);
         if (includeTlsCaddyfile && !inputs.caddyfilePath) {
@@ -415,7 +415,7 @@ export default class AppDeploy extends Command {
       const dockerfilePath =
         isVerifiable || deployExistingImageRef
           ? ""
-          : await getDockerfileInteractive(flags.dockerfile, nonInteractive);
+          : await getDockerfile(flags.dockerfile, nonInteractive);
       const buildFromDockerfile = dockerfilePath !== "";
 
       // 2. Get image reference interactively (context-aware)
@@ -434,7 +434,7 @@ export default class AppDeploy extends Command {
       );
 
       // 4. Get env file path interactively
-      envFilePath = envFilePath ?? (await getEnvFileInteractive(flags["env-file"], nonInteractive));
+      envFilePath = envFilePath ?? (await getEnvFile(flags["env-file"], nonInteractive));
 
       // 4b. Merge inline --env KEY=VALUE vars (overrides env file values)
       if (flags.env && flags.env.length > 0) {
@@ -448,7 +448,7 @@ export default class AppDeploy extends Command {
         privateKey,
         rpcUrl,
       );
-      const instanceType = await getInstanceTypeInteractive(
+      const instanceType = await getInstanceType(
         flags["instance-type"],
         "", // No pinned default for new deployments; non-interactive falls back to g1-standard-2s
         availableTypes,
@@ -456,13 +456,13 @@ export default class AppDeploy extends Command {
       );
 
       // 6. Get log visibility interactively
-      const logSettings = await getLogSettingsInteractive(
+      const logSettings = await getLogSettings(
         flags["log-visibility"] as LogVisibility | undefined,
         nonInteractive,
       );
 
       // 7. Get resource usage monitoring interactively
-      const resourceUsageMonitoring = await getResourceUsageMonitoringInteractive(
+      const resourceUsageMonitoring = await getResourceUsageMonitoring(
         flags["resource-usage-monitoring"] as ResourceUsageMonitoring | undefined,
         nonInteractive,
       );

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -44,7 +44,7 @@ import {
 } from "../../../utils/dockerhub";
 import { isTlsEnabledFromEnvFile } from "../../../utils/tls";
 import { mergeInlineEnvVars } from "../../../utils/env";
-import { EXIT_CODES, errorMessage } from "../../../utils/exitCodes";
+import { stageFailure } from "../../../utils/exitCodes";
 import type { SubmitBuildRequest } from "@layr-labs/ecloud-sdk";
 
 export default class AppDeploy extends Command {
@@ -191,10 +191,12 @@ export default class AppDeploy extends Command {
           "name",
         );
         if (missing.length > 0) {
-          this.error(
+          const { message, exit } = stageFailure(
+            "deploy",
+            "invalid-input",
             `Missing required input(s) for non-interactive deploy:\n  - ${missing.join("\n  - ")}`,
-            { exit: EXIT_CODES.INVALID_INPUT },
           );
+          this.error(message, { exit });
         }
       }
 
@@ -509,9 +511,8 @@ export default class AppDeploy extends Command {
                 billTo: "developer",
               }));
       } catch (err) {
-        this.error(`Build/push failed (no deployment was attempted): ${errorMessage(err)}`, {
-          exit: EXIT_CODES.BUILD_FAILED,
-        });
+        const { message, exit } = stageFailure("deploy", "build", err);
+        this.error(message, { exit });
       }
 
       // 9. Apply gas overrides if provided, show estimate, and prompt for confirmation on mainnet
@@ -543,11 +544,8 @@ export default class AppDeploy extends Command {
       try {
         res = await compute.app.executeDeploy(prepared, finalTx);
       } catch (err) {
-        this.error(
-          `On-chain deployment failed after the image was built and pushed: ${errorMessage(err)}\n` +
-            `The image is already pushed — re-running deploy will reuse it.`,
-          { exit: EXIT_CODES.ONCHAIN_FAILED },
-        );
+        const { message, exit } = stageFailure("deploy", "onchain", err);
+        this.error(message, { exit });
       }
 
       // 11. Collect app profile while deployment is in progress (optional)

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -170,7 +170,7 @@ export default class AppDeploy extends Command {
       const { flags } = await this.parse(AppDeploy);
 
       // Non-interactive: report every missing required input at once instead of
-      // failing one prompt at a time (RND-589).
+      // failing one prompt at a time.
       if (isNonInteractive(flags)) {
         const missing = collectMissingRequiredInputs(
           {
@@ -473,7 +473,7 @@ export default class AppDeploy extends Command {
       // the image doesn't already have it.
       // Build/push stage — failures here mean no image was produced and no
       // on-chain tx was attempted. Distinct exit code so callers don't confuse
-      // it with an on-chain failure (RND-591).
+      // it with an on-chain failure.
       let prepared, gasEstimate;
       try {
         ({ prepared, gasEstimate } =
@@ -528,7 +528,7 @@ export default class AppDeploy extends Command {
 
       // 10. Execute the deployment (on-chain stage). The image is already
       // built+pushed at this point; a failure here is distinct from a build
-      // failure and a re-run will reuse the pushed image (RND-591).
+      // failure and a re-run will reuse the pushed image.
       let res;
       try {
         res = await compute.app.executeDeploy(prepared, finalTx);

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -1,5 +1,10 @@
 import { Command, Flags } from "@oclif/core";
-import { getEnvironmentConfig, UserApiClient, isMainnet } from "@layr-labs/ecloud-sdk";
+import {
+  getEnvironmentConfig,
+  UserApiClient,
+  isMainnet,
+  WatchTimeoutError,
+} from "@layr-labs/ecloud-sdk";
 import { withTelemetry } from "../../../telemetry";
 import { commonFlags, applyTxOverrides } from "../../../flags";
 import { createComputeClient } from "../../../client";
@@ -146,6 +151,11 @@ export default class AppDeploy extends Command {
     force: Flags.boolean({
       description: "Skip all confirmation prompts",
       default: false,
+    }),
+    "watch-timeout": Flags.integer({
+      description:
+        "Maximum seconds to wait for the app to start before returning a recovery hint (default: 600)",
+      env: "ECLOUD_WATCH_TIMEOUT_SECONDS",
     }),
   };
 
@@ -533,7 +543,41 @@ export default class AppDeploy extends Command {
       }
 
       // 12. Watch until app is running
-      const ipAddress = await compute.app.watchDeployment(res.appId);
+      let ipAddress: string | undefined;
+      try {
+        ipAddress = await compute.app.watchDeployment(res.appId, {
+          timeoutSeconds: flags["watch-timeout"],
+        });
+      } catch (watchErr: any) {
+        if (watchErr instanceof WatchTimeoutError) {
+          this.log(
+            `\n${chalk.yellow("⚠")} ${chalk.yellow(
+              `Deployment did not reach Running within ${watchErr.elapsedSeconds}s (last status: ${watchErr.lastStatus ?? "unknown"}).`,
+            )}`,
+          );
+          this.log(
+            chalk.gray(
+              `The deploy transaction succeeded, but the orchestrator hasn't reported the app as Running yet.`,
+            ),
+          );
+          this.log(chalk.gray(`  appId:  ${res.appId}`));
+          if (res.txHash) {
+            this.log(chalk.gray(`  txHash: ${res.txHash}`));
+          }
+          this.log(
+            chalk.gray(
+              `Check progress later with: ${chalk.cyan(`ecloud compute app info ${res.appId}`)}`,
+            ),
+          );
+          this.log(
+            chalk.gray(
+              `Override the watch timeout with the ${chalk.cyan("ECLOUD_WATCH_TIMEOUT_SECONDS")} environment variable.`,
+            ),
+          );
+          this.exit(1);
+        }
+        throw watchErr;
+      }
 
       try {
         const cwd = process.env.INIT_CWD || process.cwd();

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -5,6 +5,7 @@ import {
   isMainnet,
   WatchTimeoutError,
 } from "@layr-labs/ecloud-sdk";
+import type { PrepareDeployResult, GasEstimate } from "@layr-labs/ecloud-sdk";
 import { withTelemetry } from "../../../telemetry";
 import { commonFlags, applyTxOverrides } from "../../../flags";
 import { createComputeClient } from "../../../client";
@@ -474,7 +475,8 @@ export default class AppDeploy extends Command {
       // Build/push stage — failures here mean no image was produced and no
       // on-chain tx was attempted. Distinct exit code so callers don't confuse
       // it with an on-chain failure.
-      let prepared, gasEstimate;
+      let prepared: PrepareDeployResult["prepared"];
+      let gasEstimate: GasEstimate;
       try {
         ({ prepared, gasEstimate } =
           verifiableMode === "git"
@@ -529,7 +531,7 @@ export default class AppDeploy extends Command {
       // 10. Execute the deployment (on-chain stage). The image is already
       // built+pushed at this point; a failure here is distinct from a build
       // failure and a re-run will reuse the pushed image.
-      let res;
+      let res: Awaited<ReturnType<typeof compute.app.executeDeploy>>;
       try {
         res = await compute.app.executeDeploy(prepared, finalTx);
       } catch (err) {

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -72,7 +72,8 @@ export default class AppDeploy extends Command {
     }),
     "log-visibility": Flags.string({
       required: false,
-      description: "Log visibility setting: public, private, or off",
+      description:
+        "Log visibility setting: public, private, or off (non-interactive default: private)",
       options: ["public", "private", "off"],
       env: "ECLOUD_LOG_VISIBILITY",
     }),
@@ -88,7 +89,8 @@ export default class AppDeploy extends Command {
     }),
     "resource-usage-monitoring": Flags.string({
       required: false,
-      description: "Resource usage monitoring: enable or disable",
+      description:
+        "Resource usage monitoring: enable or disable (non-interactive default: disable)",
       options: ["enable", "disable"],
       env: "ECLOUD_RESOURCE_USAGE_MONITORING",
     }),
@@ -359,9 +361,17 @@ export default class AppDeploy extends Command {
         }
       }
 
-      // 1. Get dockerfile path interactively (skip when using verifiable image)
+      // 1. Get dockerfile path interactively (skip when using verifiable image).
+      // Also skip when --image-ref is explicitly provided and no --dockerfile was:
+      // the user is deploying an existing image, so a stray Dockerfile in the
+      // working directory must not trigger a "build or deploy existing?" prompt
+      // (or, in non-interactive mode, silently flip the deploy to a local build).
       const isVerifiable = verifiableMode !== "none";
-      const dockerfilePath = isVerifiable ? "" : await getDockerfileInteractive(flags.dockerfile);
+      const deployExistingImageRef = !!flags["image-ref"] && !flags.dockerfile;
+      const dockerfilePath =
+        isVerifiable || deployExistingImageRef
+          ? ""
+          : await getDockerfileInteractive(flags.dockerfile);
       const buildFromDockerfile = dockerfilePath !== "";
 
       // 2. Get image reference interactively (context-aware)

--- a/packages/cli/src/commands/compute/app/deploy.ts
+++ b/packages/cli/src/commands/compute/app/deploy.ts
@@ -22,6 +22,8 @@ import {
   promptVerifiableGitSourceInputs,
   promptVerifiablePrebuiltImageRef,
   imagePathToBlob,
+  isNonInteractive,
+  collectMissingRequiredInputs,
 } from "../../../utils/prompts";
 import { invalidateProfileCache, setLinkedAppForDirectory } from "../../../utils/globalConfig";
 import { getClientId } from "../../../utils/version";
@@ -148,12 +150,36 @@ export default class AppDeploy extends Command {
     force: Flags.boolean({
       description: "Skip all confirmation prompts",
       default: false,
+      env: "ECLOUD_FORCE",
     }),
   };
 
   async run() {
     return withTelemetry(this, async () => {
       const { flags } = await this.parse(AppDeploy);
+
+      // Non-interactive: report every missing required input at once instead of
+      // failing one prompt at a time (RND-589).
+      if (isNonInteractive(flags)) {
+        const missing = collectMissingRequiredInputs(
+          {
+            imageRef: flags["image-ref"],
+            dockerfile: flags.dockerfile,
+            verifiable: flags.verifiable,
+            repo: flags.repo,
+            commit: flags.commit,
+            name: flags.name,
+          },
+          "name",
+        );
+        if (missing.length > 0) {
+          this.error(
+            `Missing required input(s) for non-interactive deploy:\n  - ${missing.join("\n  - ")}`,
+            { exit: 1 },
+          );
+        }
+      }
+
       const compute = await createComputeClient(flags);
 
       // Get validated values from flags (mutated by createComputeClient)
@@ -406,8 +432,9 @@ export default class AppDeploy extends Command {
       );
       const instanceType = await getInstanceTypeInteractive(
         flags["instance-type"],
-        "", // No default for new deployments
+        "", // No pinned default for new deployments; non-interactive falls back to g1-standard-2s
         availableTypes,
+        isNonInteractive(flags),
       );
 
       // 6. Get log visibility interactively

--- a/packages/cli/src/commands/compute/app/status.ts
+++ b/packages/cli/src/commands/compute/app/status.ts
@@ -1,0 +1,122 @@
+import { Command, Args, Flags } from "@oclif/core";
+import { getEnvironmentConfig, UserApiClient, WatchTimeoutError } from "@layr-labs/ecloud-sdk";
+import { commonFlags, validateCommonFlags } from "../../../flags";
+import { getOrPromptAppID } from "../../../utils/prompts";
+import { getClientId } from "../../../utils/version";
+import { createComputeClient } from "../../../client";
+import { createViemClients } from "../../../utils/viemClients";
+import chalk from "chalk";
+
+export default class AppStatus extends Command {
+  static description =
+    "Show an app's current status. Use --wait to block until it settles instead of polling `app info` in a loop.";
+
+  static examples = [
+    "<%= config.bin %> compute app status 0xabc...",
+    "<%= config.bin %> compute app status 0xabc... --json",
+    "<%= config.bin %> compute app status 0xabc... --wait",
+    "ECLOUD_WATCH_TIMEOUT_SECONDS=120 <%= config.bin %> compute app status 0xabc... --wait",
+  ];
+
+  static args = {
+    "app-id": Args.string({
+      description: "App ID or name (env: ECLOUD_APP_ID)",
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...commonFlags,
+    wait: Flags.boolean({
+      description:
+        "Block until the app reaches a terminal status (Running/Stopped) or the watch timeout elapses, instead of returning immediately",
+      default: false,
+    }),
+    "watch-timeout": Flags.integer({
+      description:
+        "With --wait: maximum seconds to wait before returning a recovery hint (default: 600)",
+      env: "ECLOUD_WATCH_TIMEOUT_SECONDS",
+    }),
+    json: Flags.boolean({
+      description: "Output machine-readable JSON ({ appId, status })",
+      default: false,
+    }),
+  };
+
+  async run() {
+    const { args, flags } = await this.parse(AppStatus);
+
+    const validatedFlags = await validateCommonFlags(flags);
+    const environment = validatedFlags.environment;
+    const environmentConfig = getEnvironmentConfig(environment);
+    const rpcUrl = validatedFlags["rpc-url"] || environmentConfig.defaultRPCURL;
+    const privateKey = validatedFlags["private-key"]!;
+
+    const appID = await getOrPromptAppID({
+      appID: args["app-id"] ?? process.env.ECLOUD_APP_ID,
+      environment,
+      privateKey,
+      rpcUrl,
+      action: "check status of",
+    });
+
+    const { publicClient, walletClient } = createViemClients({
+      privateKey,
+      rpcUrl,
+      environment,
+    });
+    const userApiClient = new UserApiClient(environmentConfig, walletClient, publicClient, {
+      clientId: getClientId(),
+    });
+
+    if (flags.wait) {
+      // Reuse the bounded watch machinery (RND-568/569): polls server-side at a
+      // fixed cadence with 429/5xx backoff, throws WatchTimeoutError on timeout.
+      const compute = await createComputeClient(validatedFlags);
+      try {
+        await compute.app.watchDeployment(appID, {
+          timeoutSeconds: flags["watch-timeout"],
+        });
+      } catch (err) {
+        if (err instanceof WatchTimeoutError) {
+          // Fall through to a final one-shot read + hint below rather than crash.
+          if (!flags.json) {
+            this.warn(
+              `Timed out after ${err.elapsedSeconds}s waiting for ${appID}. ` +
+                `Check 'ecloud compute app info ${appID}' or the orchestrator logs.`,
+            );
+          }
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    // One-shot status read (also the final read after --wait).
+    const statuses = await userApiClient.getStatuses([appID]);
+    const status = statuses[0]?.status || "Unknown";
+
+    if (flags.json) {
+      this.log(JSON.stringify({ appId: appID, status }));
+      return;
+    }
+
+    this.log(`${chalk.bold(appID)}: ${formatStatus(status)}`);
+  }
+}
+
+function formatStatus(status: string): string {
+  switch (status.toLowerCase()) {
+    case "running":
+    case "started":
+      return chalk.green(status);
+    case "failed":
+    case "terminated":
+      return chalk.red(status);
+    case "stopped":
+    case "suspended":
+      return chalk.yellow(status);
+    default:
+      return status;
+  }
+}

--- a/packages/cli/src/commands/compute/app/status.ts
+++ b/packages/cli/src/commands/compute/app/status.ts
@@ -70,7 +70,7 @@ export default class AppStatus extends Command {
     });
 
     if (flags.wait) {
-      // Reuse the bounded watch machinery (RND-568/569): polls server-side at a
+      // Reuse the bounded watch machinery: polls server-side at a
       // fixed cadence with 429/5xx backoff, throws WatchTimeoutError on timeout.
       const compute = await createComputeClient(validatedFlags);
       try {

--- a/packages/cli/src/commands/compute/app/status.ts
+++ b/packages/cli/src/commands/compute/app/status.ts
@@ -69,10 +69,19 @@ export default class AppStatus extends Command {
       clientId: getClientId(),
     });
 
-    if (flags.wait) {
+    // One-shot read first. --wait only blocks while the app is still
+    // transitioning; a settled status (Running/Stopped/Terminated/Failed/...)
+    // returns immediately instead of polling until the watch timeout.
+    const initialStatus = await this.readStatus(userApiClient, appID);
+
+    if (flags.wait && isTransitionalStatus(initialStatus)) {
       // Reuse the bounded watch machinery: polls server-side at a
       // fixed cadence with 429/5xx backoff, throws WatchTimeoutError on timeout.
-      const compute = await createComputeClient(validatedFlags);
+      // In --json mode, route SDK progress to stderr so stdout stays pure JSON.
+      const compute = await createComputeClient(
+        validatedFlags,
+        flags.json ? { logger: stderrLogger } : {},
+      );
       try {
         await compute.app.watchDeployment(appID, {
           timeoutSeconds: flags["watch-timeout"],
@@ -90,20 +99,62 @@ export default class AppStatus extends Command {
           throw err;
         }
       }
-    }
 
-    // One-shot status read (also the final read after --wait).
-    const statuses = await userApiClient.getStatuses([appID]);
-    const status = statuses[0]?.status || "Unknown";
-
-    if (flags.json) {
-      this.log(JSON.stringify({ appId: appID, status }));
+      // Final read after waiting; the status has (hopefully) settled.
+      const finalStatus = await this.readStatus(userApiClient, appID);
+      this.emit(appID, finalStatus, flags.json);
       return;
     }
 
+    this.emit(appID, initialStatus, flags.json);
+  }
+
+  /** Fetch the current status for an app, defaulting to "Unknown". */
+  private async readStatus(userApiClient: UserApiClient, appID: string): Promise<string> {
+    const statuses = await userApiClient.getStatuses([appID]);
+    return statuses[0]?.status || "Unknown";
+  }
+
+  /** Write the status as JSON (machine-readable) or a formatted line. */
+  private emit(appID: string, status: string, json: boolean): void {
+    if (json) {
+      this.log(JSON.stringify({ appId: appID, status }));
+      return;
+    }
     this.log(`${chalk.bold(appID)}: ${formatStatus(status)}`);
   }
 }
+
+/**
+ * Statuses that represent an in-progress transition the orchestrator will move
+ * out of on its own. Only these are worth blocking on with --wait; any other
+ * (settled) status returns immediately. Compared case-insensitively so a casing
+ * change on the server side doesn't silently turn --wait into a no-op.
+ */
+const TRANSITIONAL_STATUSES = new Set([
+  "created",
+  "deploying",
+  "upgrading",
+  "resuming",
+  "stopping",
+  "terminating",
+]);
+
+function isTransitionalStatus(status: string): boolean {
+  return TRANSITIONAL_STATUSES.has(status.toLowerCase());
+}
+
+/**
+ * Logger that routes every level to stderr. Used in --json mode so SDK
+ * progress output ("Waiting for app to start...", "Status: ...") never
+ * pollutes the JSON object on stdout.
+ */
+const stderrLogger = {
+  debug: (...args: unknown[]) => console.error(...args),
+  info: (...args: unknown[]) => console.error(...args),
+  warn: (...args: unknown[]) => console.error(...args),
+  error: (...args: unknown[]) => console.error(...args),
+};
 
 function formatStatus(status: string): string {
   switch (status.toLowerCase()) {

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -40,6 +40,7 @@ import {
 } from "../../../utils/dockerhub";
 import { isTlsEnabledFromEnvFile } from "../../../utils/tls";
 import { mergeInlineEnvVars } from "../../../utils/env";
+import { EXIT_CODES, errorMessage } from "../../../utils/exitCodes";
 import type { SubmitBuildRequest } from "@layr-labs/ecloud-sdk";
 
 export default class AppUpgrade extends Command {
@@ -174,7 +175,7 @@ export default class AppUpgrade extends Command {
         if (missing.length > 0) {
           this.error(
             `Missing required input(s) for non-interactive upgrade:\n  - ${missing.join("\n  - ")}`,
-            { exit: 1 },
+            { exit: EXIT_CODES.INVALID_INPUT },
           );
         }
       }
@@ -415,24 +416,33 @@ export default class AppUpgrade extends Command {
       // the normal prepareUpgrade path so that layerRemoteImageIfNeeded can
       // add the ecloud runtime layer (startup script, KMS client, Caddy) if
       // the image doesn't already have it.
-      const { prepared, gasEstimate } =
-        verifiableMode === "git"
-          ? await compute.app.prepareUpgradeFromVerifiableBuild(appID, {
-              imageRef,
-              imageDigest: verifiableImageDigest!,
-              envFile: envFilePath,
-              instanceType,
-              logVisibility,
-              resourceUsageMonitoring,
-            })
-          : await compute.app.prepareUpgrade(appID, {
-              dockerfile: dockerfilePath,
-              imageRef,
-              envFile: envFilePath,
-              instanceType,
-              logVisibility,
-              resourceUsageMonitoring,
-            });
+      // Build/push stage — failures here mean no image was produced and no
+      // on-chain tx was attempted (RND-591).
+      let prepared, gasEstimate;
+      try {
+        ({ prepared, gasEstimate } =
+          verifiableMode === "git"
+            ? await compute.app.prepareUpgradeFromVerifiableBuild(appID, {
+                imageRef,
+                imageDigest: verifiableImageDigest!,
+                envFile: envFilePath,
+                instanceType,
+                logVisibility,
+                resourceUsageMonitoring,
+              })
+            : await compute.app.prepareUpgrade(appID, {
+                dockerfile: dockerfilePath,
+                imageRef,
+                envFile: envFilePath,
+                instanceType,
+                logVisibility,
+                resourceUsageMonitoring,
+              }));
+      } catch (err) {
+        this.error(`Build/push failed (no upgrade was attempted): ${errorMessage(err)}`, {
+          exit: EXIT_CODES.BUILD_FAILED,
+        });
+      }
 
       // 10. Apply gas overrides if provided, show estimate, and prompt for confirmation on mainnet
       const finalTx = await applyTxOverrides(gasEstimate, flags, { publicClient, address });
@@ -456,8 +466,19 @@ export default class AppUpgrade extends Command {
         }
       }
 
-      // 11. Execute the upgrade
-      const res = await compute.app.executeUpgrade(prepared, finalTx);
+      // 11. Execute the upgrade (on-chain stage). Image already built+pushed;
+      // a failure here is distinct from a build failure and a re-run reuses the
+      // pushed image (RND-591).
+      let res;
+      try {
+        res = await compute.app.executeUpgrade(prepared, finalTx);
+      } catch (err) {
+        this.error(
+          `On-chain upgrade failed after the image was built and pushed: ${errorMessage(err)}\n` +
+            `The image is already pushed — re-running upgrade will reuse it.`,
+          { exit: EXIT_CODES.ONCHAIN_FAILED },
+        );
+      }
 
       // 12. Watch until upgrade completes
       try {

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -157,9 +157,15 @@ export default class AppUpgrade extends Command {
       // (oclif Args don't support env bindings directly).
       const appIdInput = args["app-id"] ?? process.env.ECLOUD_APP_ID;
 
+      // Resolve the interactivity decision once (flag › CI › !TTY) and thread it
+      // into the optional-input helpers. They take it as a parameter rather than
+      // re-deriving from process internally, so --non-interactive is honored
+      // even on a TTY and the helpers stay pure/testable.
+      const nonInteractive = isNonInteractive(flags);
+
       // Non-interactive: report every missing required input at once instead of
       // failing one prompt at a time.
-      if (isNonInteractive(flags)) {
+      if (nonInteractive) {
         const missing = collectMissingRequiredInputs(
           {
             imageRef: flags["image-ref"],
@@ -264,7 +270,7 @@ export default class AppUpgrade extends Command {
           : await promptVerifiableGitSourceInputs();
 
         // Prompt for env file after git inputs
-        envFilePath = await getEnvFileInteractive(flags["env-file"]);
+        envFilePath = await getEnvFileInteractive(flags["env-file"], nonInteractive);
         const includeTlsCaddyfile = isTlsEnabledFromEnvFile(envFilePath);
         if (includeTlsCaddyfile && !inputs.caddyfilePath) {
           inputs.caddyfilePath = "Caddyfile";
@@ -346,7 +352,7 @@ export default class AppUpgrade extends Command {
       const dockerfilePath =
         isVerifiable || deployExistingImageRef
           ? ""
-          : await getDockerfileInteractive(flags.dockerfile);
+          : await getDockerfileInteractive(flags.dockerfile, nonInteractive);
       const buildFromDockerfile = dockerfilePath !== "";
 
       // 3. Get image reference interactively (context-aware)
@@ -355,7 +361,7 @@ export default class AppUpgrade extends Command {
         : await getImageReferenceInteractive(flags["image-ref"], buildFromDockerfile);
 
       // 4. Get env file path interactively
-      envFilePath = envFilePath ?? (await getEnvFileInteractive(flags["env-file"]));
+      envFilePath = envFilePath ?? (await getEnvFileInteractive(flags["env-file"], nonInteractive));
 
       // 4b. Merge inline --env KEY=VALUE vars (overrides env file values)
       if (flags.env && flags.env.length > 0) {
@@ -392,17 +398,19 @@ export default class AppUpgrade extends Command {
         flags["instance-type"],
         currentInstanceType,
         availableTypes,
-        isNonInteractive(flags),
+        nonInteractive,
       );
 
       // 7. Get log visibility interactively
       const logSettings = await getLogSettingsInteractive(
         flags["log-visibility"] as LogVisibility | undefined,
+        nonInteractive,
       );
 
       // 8. Get resource usage monitoring interactively
       const resourceUsageMonitoring = await getResourceUsageMonitoringInteractive(
         flags["resource-usage-monitoring"] as ResourceUsageMonitoring | undefined,
+        nonInteractive,
       );
 
       // 9. Prepare upgrade (builds image, pushes to registry, prepares batch, estimates gas)

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -157,7 +157,7 @@ export default class AppUpgrade extends Command {
       const appIdInput = args["app-id"] ?? process.env.ECLOUD_APP_ID;
 
       // Non-interactive: report every missing required input at once instead of
-      // failing one prompt at a time (RND-589).
+      // failing one prompt at a time.
       if (isNonInteractive(flags)) {
         const missing = collectMissingRequiredInputs(
           {
@@ -417,7 +417,7 @@ export default class AppUpgrade extends Command {
       // add the ecloud runtime layer (startup script, KMS client, Caddy) if
       // the image doesn't already have it.
       // Build/push stage — failures here mean no image was produced and no
-      // on-chain tx was attempted (RND-591).
+      // on-chain tx was attempted.
       let prepared, gasEstimate;
       try {
         ({ prepared, gasEstimate } =
@@ -468,7 +468,7 @@ export default class AppUpgrade extends Command {
 
       // 11. Execute the upgrade (on-chain stage). Image already built+pushed;
       // a failure here is distinct from a build failure and a re-run reuses the
-      // pushed image (RND-591).
+      // pushed image.
       let res;
       try {
         res = await compute.app.executeUpgrade(prepared, finalTx);

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -15,7 +15,6 @@ import {
   getImageReferenceInteractive,
   getEnvFile,
   getInstanceType,
-  type SkuInfo,
   getLogSettings,
   getResourceUsageMonitoring,
   getOrPromptAppID,
@@ -30,6 +29,7 @@ import {
   collectMissingRequiredInputs,
 } from "../../../utils/prompts";
 import { getClientId } from "../../../utils/version";
+import { fetchAvailableInstanceTypes } from "../../../utils/instanceTypes";
 import { setLinkedAppForDirectory, invalidateProfileCache } from "../../../utils/globalConfig";
 import chalk from "chalk";
 import { formatVerifiableBuildSummary } from "../../../utils/build";
@@ -565,37 +565,5 @@ export default class AppUpgrade extends Command {
         ),
       );
     });
-  }
-}
-
-/**
- * Fetch available instance types from backend
- */
-async function fetchAvailableInstanceTypes(
-  environment: string,
-  environmentConfig: any,
-  privateKey: string,
-  rpcUrl: string,
-): Promise<SkuInfo[]> {
-  try {
-    const { publicClient, walletClient } = createViemClients({
-      privateKey,
-      rpcUrl,
-      environment,
-    });
-    const userApiClient = new UserApiClient(environmentConfig, walletClient, publicClient, {
-      clientId: getClientId(),
-    });
-
-    const skuList = await userApiClient.getSKUs();
-    if (skuList.skus.length === 0) {
-      throw new Error("No instance types available from server");
-    }
-
-    return skuList.skus;
-  } catch (err: any) {
-    console.warn(`Failed to fetch instance types: ${err.message}`);
-    // Return a default fallback
-    return [{ sku: "g1-standard-4t", description: "4 vCPUs, 16 GB memory, TDX" }];
   }
 }

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -41,7 +41,7 @@ import {
 } from "../../../utils/dockerhub";
 import { isTlsEnabledFromEnvFile } from "../../../utils/tls";
 import { mergeInlineEnvVars } from "../../../utils/env";
-import { EXIT_CODES, errorMessage } from "../../../utils/exitCodes";
+import { stageFailure } from "../../../utils/exitCodes";
 import type { SubmitBuildRequest } from "@layr-labs/ecloud-sdk";
 
 export default class AppUpgrade extends Command {
@@ -180,10 +180,12 @@ export default class AppUpgrade extends Command {
           missing.push("app-id (positional arg or ECLOUD_APP_ID)");
         }
         if (missing.length > 0) {
-          this.error(
+          const { message, exit } = stageFailure(
+            "upgrade",
+            "invalid-input",
             `Missing required input(s) for non-interactive upgrade:\n  - ${missing.join("\n  - ")}`,
-            { exit: EXIT_CODES.INVALID_INPUT },
           );
+          this.error(message, { exit });
         }
       }
 
@@ -449,9 +451,8 @@ export default class AppUpgrade extends Command {
                 resourceUsageMonitoring,
               }));
       } catch (err) {
-        this.error(`Build/push failed (no upgrade was attempted): ${errorMessage(err)}`, {
-          exit: EXIT_CODES.BUILD_FAILED,
-        });
+        const { message, exit } = stageFailure("upgrade", "build", err);
+        this.error(message, { exit });
       }
 
       // 10. Apply gas overrides if provided, show estimate, and prompt for confirmation on mainnet
@@ -483,11 +484,8 @@ export default class AppUpgrade extends Command {
       try {
         res = await compute.app.executeUpgrade(prepared, finalTx);
       } catch (err) {
-        this.error(
-          `On-chain upgrade failed after the image was built and pushed: ${errorMessage(err)}\n` +
-            `The image is already pushed — re-running upgrade will reuse it.`,
-          { exit: EXIT_CODES.ONCHAIN_FAILED },
-        );
+        const { message, exit } = stageFailure("upgrade", "onchain", err);
+        this.error(message, { exit });
       }
 
       // 12. Watch until upgrade completes

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -76,7 +76,8 @@ export default class AppUpgrade extends Command {
     }),
     "log-visibility": Flags.string({
       required: false,
-      description: "Log visibility setting: public, private, or off",
+      description:
+        "Log visibility setting: public, private, or off (non-interactive default: private)",
       options: ["public", "private", "off"],
       env: "ECLOUD_LOG_VISIBILITY",
     }),
@@ -87,7 +88,8 @@ export default class AppUpgrade extends Command {
     }),
     "resource-usage-monitoring": Flags.string({
       required: false,
-      description: "Resource usage monitoring: enable or disable",
+      description:
+        "Resource usage monitoring: enable or disable (non-interactive default: disable)",
       options: ["enable", "disable"],
       env: "ECLOUD_RESOURCE_USAGE_MONITORING",
     }),
@@ -290,9 +292,17 @@ export default class AppUpgrade extends Command {
         }
       }
 
-      // 2. Get dockerfile path interactively (skip when using verifiable image)
+      // 2. Get dockerfile path interactively (skip when using verifiable image).
+      // Also skip when --image-ref is explicitly provided and no --dockerfile was:
+      // the user is upgrading to an existing image, so a stray Dockerfile in the
+      // working directory must not trigger a "build or deploy existing?" prompt
+      // (or, in non-interactive mode, silently flip the upgrade to a local build).
       const isVerifiable = verifiableMode !== "none";
-      const dockerfilePath = isVerifiable ? "" : await getDockerfileInteractive(flags.dockerfile);
+      const deployExistingImageRef = !!flags["image-ref"] && !flags.dockerfile;
+      const dockerfilePath =
+        isVerifiable || deployExistingImageRef
+          ? ""
+          : await getDockerfileInteractive(flags.dockerfile);
       const buildFromDockerfile = dockerfilePath !== "";
 
       // 3. Get image reference interactively (context-aware)

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -1,5 +1,10 @@
 import { Command, Args, Flags } from "@oclif/core";
-import { getEnvironmentConfig, UserApiClient, isMainnet } from "@layr-labs/ecloud-sdk";
+import {
+  getEnvironmentConfig,
+  UserApiClient,
+  isMainnet,
+  WatchTimeoutError,
+} from "@layr-labs/ecloud-sdk";
 import { withTelemetry } from "../../../telemetry";
 import { commonFlags, applyTxOverrides } from "../../../flags";
 import { createBuildClient, createComputeClient } from "../../../client";
@@ -129,6 +134,11 @@ export default class AppUpgrade extends Command {
     force: Flags.boolean({
       description: "Skip all confirmation prompts",
       default: false,
+    }),
+    "watch-timeout": Flags.integer({
+      description:
+        "Maximum seconds to wait for the upgrade to complete before returning a recovery hint (default: 600)",
+      env: "ECLOUD_WATCH_TIMEOUT_SECONDS",
     }),
   };
 
@@ -407,7 +417,32 @@ export default class AppUpgrade extends Command {
       const res = await compute.app.executeUpgrade(prepared, finalTx);
 
       // 12. Watch until upgrade completes
-      await compute.app.watchUpgrade(res.appId);
+      try {
+        await compute.app.watchUpgrade(res.appId, { timeoutSeconds: flags["watch-timeout"] });
+      } catch (err: any) {
+        if (err instanceof WatchTimeoutError) {
+          this.log("");
+          this.log(
+            chalk.yellow(
+              `Timed out after ${err.elapsedSeconds}s waiting for upgrade to complete (last status: ${err.lastStatus ?? "unknown"}).`,
+            ),
+          );
+          this.log(chalk.gray("The on-chain transaction was submitted; the orchestrator may"));
+          this.log(chalk.gray("still be processing. To check the current status, run:"));
+          this.log("");
+          this.log(`  ${chalk.cyan(`ecloud compute app info ${res.appId}`)}`);
+          this.log("");
+          this.log(chalk.gray(`appId:  ${res.appId}`));
+          this.log(chalk.gray(`txHash: ${res.txHash}`));
+          this.log(
+            chalk.gray(
+              `(override the watch deadline with ECLOUD_WATCH_TIMEOUT_SECONDS, currently ${err.timeoutSeconds}s)`,
+            ),
+          );
+          this.exit(1);
+        }
+        throw err;
+      }
 
       try {
         const cwd = process.env.INIT_CWD || process.cwd();

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -11,13 +11,13 @@ import { commonFlags, applyTxOverrides } from "../../../flags";
 import { createBuildClient, createComputeClient } from "../../../client";
 import { createViemClients } from "../../../utils/viemClients";
 import {
-  getDockerfileInteractive,
+  getDockerfile,
   getImageReferenceInteractive,
-  getEnvFileInteractive,
-  getInstanceTypeInteractive,
+  getEnvFile,
+  getInstanceType,
   type SkuInfo,
-  getLogSettingsInteractive,
-  getResourceUsageMonitoringInteractive,
+  getLogSettings,
+  getResourceUsageMonitoring,
   getOrPromptAppID,
   LogVisibility,
   ResourceUsageMonitoring,
@@ -270,7 +270,7 @@ export default class AppUpgrade extends Command {
           : await promptVerifiableGitSourceInputs();
 
         // Prompt for env file after git inputs
-        envFilePath = await getEnvFileInteractive(flags["env-file"], nonInteractive);
+        envFilePath = await getEnvFile(flags["env-file"], nonInteractive);
         const includeTlsCaddyfile = isTlsEnabledFromEnvFile(envFilePath);
         if (includeTlsCaddyfile && !inputs.caddyfilePath) {
           inputs.caddyfilePath = "Caddyfile";
@@ -352,7 +352,7 @@ export default class AppUpgrade extends Command {
       const dockerfilePath =
         isVerifiable || deployExistingImageRef
           ? ""
-          : await getDockerfileInteractive(flags.dockerfile, nonInteractive);
+          : await getDockerfile(flags.dockerfile, nonInteractive);
       const buildFromDockerfile = dockerfilePath !== "";
 
       // 3. Get image reference interactively (context-aware)
@@ -361,7 +361,7 @@ export default class AppUpgrade extends Command {
         : await getImageReferenceInteractive(flags["image-ref"], buildFromDockerfile);
 
       // 4. Get env file path interactively
-      envFilePath = envFilePath ?? (await getEnvFileInteractive(flags["env-file"], nonInteractive));
+      envFilePath = envFilePath ?? (await getEnvFile(flags["env-file"], nonInteractive));
 
       // 4b. Merge inline --env KEY=VALUE vars (overrides env file values)
       if (flags.env && flags.env.length > 0) {
@@ -394,7 +394,7 @@ export default class AppUpgrade extends Command {
         privateKey,
         rpcUrl,
       );
-      const instanceType = await getInstanceTypeInteractive(
+      const instanceType = await getInstanceType(
         flags["instance-type"],
         currentInstanceType,
         availableTypes,
@@ -402,13 +402,13 @@ export default class AppUpgrade extends Command {
       );
 
       // 7. Get log visibility interactively
-      const logSettings = await getLogSettingsInteractive(
+      const logSettings = await getLogSettings(
         flags["log-visibility"] as LogVisibility | undefined,
         nonInteractive,
       );
 
       // 8. Get resource usage monitoring interactively
-      const resourceUsageMonitoring = await getResourceUsageMonitoringInteractive(
+      const resourceUsageMonitoring = await getResourceUsageMonitoring(
         flags["resource-usage-monitoring"] as ResourceUsageMonitoring | undefined,
         nonInteractive,
       );

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -5,6 +5,7 @@ import {
   isMainnet,
   WatchTimeoutError,
 } from "@layr-labs/ecloud-sdk";
+import type { PrepareUpgradeResult, GasEstimate } from "@layr-labs/ecloud-sdk";
 import { withTelemetry } from "../../../telemetry";
 import { commonFlags, applyTxOverrides } from "../../../flags";
 import { createBuildClient, createComputeClient } from "../../../client";
@@ -418,7 +419,8 @@ export default class AppUpgrade extends Command {
       // the image doesn't already have it.
       // Build/push stage — failures here mean no image was produced and no
       // on-chain tx was attempted.
-      let prepared, gasEstimate;
+      let prepared: PrepareUpgradeResult["prepared"];
+      let gasEstimate: GasEstimate;
       try {
         ({ prepared, gasEstimate } =
           verifiableMode === "git"
@@ -469,7 +471,7 @@ export default class AppUpgrade extends Command {
       // 11. Execute the upgrade (on-chain stage). Image already built+pushed;
       // a failure here is distinct from a build failure and a re-run reuses the
       // pushed image.
-      let res;
+      let res: Awaited<ReturnType<typeof compute.app.executeUpgrade>>;
       try {
         res = await compute.app.executeUpgrade(prepared, finalTx);
       } catch (err) {

--- a/packages/cli/src/commands/compute/app/upgrade.ts
+++ b/packages/cli/src/commands/compute/app/upgrade.ts
@@ -20,6 +20,8 @@ import {
   promptVerifiableSourceType,
   promptVerifiableGitSourceInputs,
   promptVerifiablePrebuiltImageRef,
+  isNonInteractive,
+  collectMissingRequiredInputs,
 } from "../../../utils/prompts";
 import { getClientId } from "../../../utils/version";
 import { setLinkedAppForDirectory, invalidateProfileCache } from "../../../utils/globalConfig";
@@ -40,7 +42,7 @@ export default class AppUpgrade extends Command {
 
   static args = {
     "app-id": Args.string({
-      description: "App ID or name to upgrade",
+      description: "App ID or name to upgrade (env: ECLOUD_APP_ID)",
       required: false,
     }),
   };
@@ -131,12 +133,42 @@ export default class AppUpgrade extends Command {
     force: Flags.boolean({
       description: "Skip all confirmation prompts",
       default: false,
+      env: "ECLOUD_FORCE",
     }),
   };
 
   async run() {
     return withTelemetry(this, async () => {
       const { args, flags } = await this.parse(AppUpgrade);
+
+      // Resolve the app to upgrade from the positional arg or ECLOUD_APP_ID env
+      // (oclif Args don't support env bindings directly).
+      const appIdInput = args["app-id"] ?? process.env.ECLOUD_APP_ID;
+
+      // Non-interactive: report every missing required input at once instead of
+      // failing one prompt at a time (RND-589).
+      if (isNonInteractive(flags)) {
+        const missing = collectMissingRequiredInputs(
+          {
+            imageRef: flags["image-ref"],
+            dockerfile: flags.dockerfile,
+            verifiable: flags.verifiable,
+            repo: flags.repo,
+            commit: flags.commit,
+          },
+          "app-id",
+        );
+        if (!appIdInput) {
+          missing.push("app-id (positional arg or ECLOUD_APP_ID)");
+        }
+        if (missing.length > 0) {
+          this.error(
+            `Missing required input(s) for non-interactive upgrade:\n  - ${missing.join("\n  - ")}`,
+            { exit: 1 },
+          );
+        }
+      }
+
       const compute = await createComputeClient(flags);
 
       // Get validated values from flags (mutated by createComputeClient)
@@ -147,7 +179,7 @@ export default class AppUpgrade extends Command {
 
       // 1. Get app ID interactively if not provided
       const appID = await getOrPromptAppID({
-        appID: args["app-id"],
+        appID: appIdInput,
         environment,
         privateKey,
         rpcUrl,
@@ -348,6 +380,7 @@ export default class AppUpgrade extends Command {
         flags["instance-type"],
         currentInstanceType,
         availableTypes,
+        isNonInteractive(flags),
       );
 
       // 7. Get log visibility interactively

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -12,6 +12,7 @@ export type CommonFlags = {
   "max-fee-per-gas"?: string;
   "max-priority-fee"?: string;
   nonce?: string;
+  "non-interactive"?: boolean;
 };
 
 export const commonFlags = {
@@ -20,7 +21,7 @@ export const commonFlags = {
     description: "Deployment environment to use",
     env: "ECLOUD_ENV",
     default: async () =>
-      getDefaultEnvironment() || (getBuildType() === "dev" ? "sepolia-dev" : "sepolia"),
+      getDefaultEnvironment() || (getBuildType() === "dev" ? "sepolia-dev" : "mainnet-alpha"),
   }),
   "private-key": Flags.string({
     required: false,
@@ -50,6 +51,13 @@ export const commonFlags = {
   nonce: Flags.string({
     required: false,
     description: 'Override transaction nonce (integer or "latest" to replace a stuck transaction)',
+  }),
+  "non-interactive": Flags.boolean({
+    required: false,
+    description:
+      "Assume non-interactive mode: default safe prompts and error all-at-once on missing required inputs",
+    env: "ECLOUD_NON_INTERACTIVE",
+    default: false,
   }),
 };
 

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -110,7 +110,9 @@ export async function applyTxOverrides(
     } else {
       const parsed = Number(nonceStr);
       if (!Number.isInteger(parsed) || parsed < 0) {
-        throw new Error(`Invalid nonce: "${nonceStr}". Must be a non-negative integer or "latest".`);
+        throw new Error(
+          `Invalid nonce: "${nonceStr}". Must be a non-negative integer or "latest".`,
+        );
       }
       nonce = parsed;
     }

--- a/packages/cli/src/hooks/init/__tests__/version-check.test.ts
+++ b/packages/cli/src/hooks/init/__tests__/version-check.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 
 vi.mock("@inquirer/prompts", () => ({
   confirm: vi.fn(),
@@ -45,12 +45,24 @@ function mockFetch(distTags: Record<string, string> | null, ok = true) {
 }
 
 describe("version-check init hook", () => {
+  const origTTY = process.stdin.isTTY;
+  const origCI = process.env.CI;
+
   beforeEach(() => {
     vi.clearAllMocks();
     (getCliVersion as Mock).mockReturnValue("1.0.0");
     (getBuildType as Mock).mockReturnValue("prod");
     (loadGlobalConfig as Mock).mockReturnValue({});
     (saveGlobalConfig as Mock).mockImplementation(() => {});
+    // Default to an interactive terminal so the update-prompt path runs.
+    process.stdin.isTTY = true;
+    delete process.env.CI;
+  });
+
+  afterEach(() => {
+    process.stdin.isTTY = origTTY;
+    if (origCI === undefined) delete process.env.CI;
+    else process.env.CI = origCI;
   });
 
   it("skips check for upgrade command", async () => {
@@ -96,6 +108,30 @@ describe("version-check init hook", () => {
     expect(ctx.log).toHaveBeenCalled();
     expect(confirm).toHaveBeenCalled();
     expect(upgradePackage).not.toHaveBeenCalled();
+  });
+
+  // RND-589: in non-interactive mode the hook must not block on the update
+  // prompt (it ran before the command and read as a failure in CI/agents).
+  it("does not prompt in non-interactive mode (no TTY)", async () => {
+    process.stdin.isTTY = false;
+    mockFetch({ latest: "2.0.0" });
+    const ctx = createMockContext();
+
+    await hook.call(ctx as any, { id: "auth:login" } as any);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(upgradePackage).not.toHaveBeenCalled();
+  });
+
+  it("does not prompt when CI=true even on a TTY", async () => {
+    process.stdin.isTTY = true;
+    process.env.CI = "true";
+    mockFetch({ latest: "2.0.0" });
+    const ctx = createMockContext();
+
+    await hook.call(ctx as any, { id: "auth:login" } as any);
+
+    expect(confirm).not.toHaveBeenCalled();
   });
 
   it("upgrades when user confirms", async () => {

--- a/packages/cli/src/hooks/init/__tests__/version-check.test.ts
+++ b/packages/cli/src/hooks/init/__tests__/version-check.test.ts
@@ -110,7 +110,7 @@ describe("version-check init hook", () => {
     expect(upgradePackage).not.toHaveBeenCalled();
   });
 
-  // RND-589: in non-interactive mode the hook must not block on the update
+  // In non-interactive mode the hook must not block on the update
   // prompt (it ran before the command and read as a failure in CI/agents).
   it("does not prompt in non-interactive mode (no TTY)", async () => {
     process.stdin.isTTY = false;

--- a/packages/cli/src/hooks/init/version-check.ts
+++ b/packages/cli/src/hooks/init/version-check.ts
@@ -12,7 +12,12 @@ const NPM_REGISTRY_URL = "https://registry.npmjs.org/@layr-labs/ecloud-cli";
 const VERSION_CHECK_TIMEOUT_MS = 3000;
 const VERSION_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-function parseVersion(v: string): { major: number; minor: number; patch: number; prerelease: string | null } {
+function parseVersion(v: string): {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+} {
   const clean = v.replace(/^v/, "");
   const [core, ...rest] = clean.split("-");
   const [major = 0, minor = 0, patch = 0] = core.split(".").map(Number);

--- a/packages/cli/src/hooks/init/version-check.ts
+++ b/packages/cli/src/hooks/init/version-check.ts
@@ -117,7 +117,7 @@ const hook: Hook<"init"> = async function (options) {
 
   // Non-interactive (CI / no TTY): never block the command on an update prompt.
   // The hook runs before the command parses flags, so it cannot see
-  // --non-interactive; CI and isTTY cover the agent/CI failure mode (RND-589).
+  // --non-interactive; CI and isTTY cover the agent/CI failure mode.
   if (process.env.CI === "true" || !process.stdin.isTTY) {
     globalConfig.last_version_check = now;
     saveGlobalConfig(globalConfig);

--- a/packages/cli/src/hooks/init/version-check.ts
+++ b/packages/cli/src/hooks/init/version-check.ts
@@ -110,6 +110,15 @@ const hook: Hook<"init"> = async function (options) {
     ),
   );
 
+  // Non-interactive (CI / no TTY): never block the command on an update prompt.
+  // The hook runs before the command parses flags, so it cannot see
+  // --non-interactive; CI and isTTY cover the agent/CI failure mode (RND-589).
+  if (process.env.CI === "true" || !process.stdin.isTTY) {
+    globalConfig.last_version_check = now;
+    saveGlobalConfig(globalConfig);
+    return;
+  }
+
   const shouldUpdate = await confirm({
     message: "Would you like to update now?",
     default: true,

--- a/packages/cli/src/utils/__tests__/dockerhub.test.ts
+++ b/packages/cli/src/utils/__tests__/dockerhub.test.ts
@@ -43,7 +43,7 @@ function stubFetch(handlers: {
   );
 }
 
-describe("resolveDockerHubImageDigest amd64 enforcement (RND-597)", () => {
+describe("resolveDockerHubImageDigest amd64 enforcement", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it("accepts a multi-platform image that includes linux/amd64", async () => {

--- a/packages/cli/src/utils/__tests__/dockerhub.test.ts
+++ b/packages/cli/src/utils/__tests__/dockerhub.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveDockerHubImageDigest } from "../dockerhub";
+
+const IMAGE = "docker.io/eigenlayer/eigencloud-containers:demo";
+const DIGEST = "sha256:" + "a".repeat(64);
+
+/** Build a fetch stub that routes by URL/method to canned responses. */
+function stubFetch(handlers: {
+  manifestList?: unknown; // multi-platform index returned for the manifest GET
+  singleManifest?: { config: { digest: string } }; // single-platform manifest
+  config?: { os?: string; architecture?: string }; // config blob
+}) {
+  const json = (body: unknown, headers: Record<string, string> = {}) =>
+    ({
+      ok: true,
+      status: 200,
+      headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    }) as unknown as Response;
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL, init?: { method?: string }) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+
+      if (url.includes("auth.docker.io/token")) return json({ token: "t" });
+
+      if (url.includes("/manifests/")) {
+        // The digest HEAD/GET: return the content-digest header.
+        if (method === "HEAD") return json({}, { "docker-content-digest": DIGEST });
+        // The platform-check GET (Accept includes index types) OR digest GET fallback.
+        if (handlers.manifestList)
+          return json(handlers.manifestList, { "docker-content-digest": DIGEST });
+        return json(handlers.singleManifest ?? {}, { "docker-content-digest": DIGEST });
+      }
+
+      if (url.includes("/blobs/")) return json(handlers.config ?? {});
+
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }),
+  );
+}
+
+describe("resolveDockerHubImageDigest amd64 enforcement (RND-597)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("accepts a multi-platform image that includes linux/amd64", async () => {
+    stubFetch({
+      manifestList: {
+        manifests: [
+          { platform: { os: "linux", architecture: "arm64" } },
+          { platform: { os: "linux", architecture: "amd64" } },
+        ],
+      },
+    });
+    await expect(resolveDockerHubImageDigest(IMAGE)).resolves.toBe(DIGEST);
+  });
+
+  it("rejects a multi-platform image with no linux/amd64 entry", async () => {
+    stubFetch({
+      manifestList: { manifests: [{ platform: { os: "linux", architecture: "arm64" } }] },
+    });
+    await expect(resolveDockerHubImageDigest(IMAGE)).rejects.toThrow(/linux\/amd64/);
+  });
+
+  it("accepts a single-platform linux/amd64 image (config blob)", async () => {
+    stubFetch({
+      singleManifest: { config: { digest: "sha256:" + "c".repeat(64) } },
+      config: { os: "linux", architecture: "amd64" },
+    });
+    await expect(resolveDockerHubImageDigest(IMAGE)).resolves.toBe(DIGEST);
+  });
+
+  it("rejects a single-platform arm64 image", async () => {
+    stubFetch({
+      singleManifest: { config: { digest: "sha256:" + "c".repeat(64) } },
+      config: { os: "linux", architecture: "arm64" },
+    });
+    await expect(resolveDockerHubImageDigest(IMAGE)).rejects.toThrow(/linux\/amd64/);
+  });
+});

--- a/packages/cli/src/utils/__tests__/exitCodes.test.ts
+++ b/packages/cli/src/utils/__tests__/exitCodes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { EXIT_CODES, errorMessage } from "../exitCodes";
+
+describe("deploy/upgrade exit codes (RND-591)", () => {
+  it("uses distinct, stable codes per failure stage", () => {
+    expect(EXIT_CODES.INVALID_INPUT).toBe(2);
+    expect(EXIT_CODES.BUILD_FAILED).toBe(3);
+    expect(EXIT_CODES.ONCHAIN_FAILED).toBe(4);
+    // All distinct.
+    expect(new Set(Object.values(EXIT_CODES)).size).toBe(3);
+  });
+
+  it("errorMessage extracts Error.message", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("errorMessage stringifies non-Error values", () => {
+    expect(errorMessage("plain string")).toBe("plain string");
+    expect(errorMessage(42)).toBe("42");
+  });
+});

--- a/packages/cli/src/utils/__tests__/exitCodes.test.ts
+++ b/packages/cli/src/utils/__tests__/exitCodes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { EXIT_CODES, errorMessage, stageFailure } from "../exitCodes";
+import { InsufficientGasError } from "@layr-labs/ecloud-sdk";
 
 describe("errorMessage", () => {
   it("extracts Error.message", () => {
@@ -41,6 +42,22 @@ describe("stageFailure — maps a failed deploy/upgrade stage to message + exit 
     const onchain = stageFailure("upgrade", "onchain", new Error("x"));
     expect(onchain.message).toContain("On-chain upgrade failed");
     expect(onchain.message).toContain("re-running upgrade will reuse it");
+  });
+
+  it("reclassifies an insufficient-gas failure caught in the build stage as on-chain (exit 4)", () => {
+    // The gas pre-flight runs inside prepare*() AFTER the image is built+pushed,
+    // so it surfaces through the build try/catch. But the image already exists,
+    // so it must NOT be reported as exit 3 "no <op> was attempted" — it is an
+    // on-chain-readiness failure (exit 4, "re-run reuses the pushed image").
+    const gasErr = new InsufficientGasError({
+      address: "0xabc0000000000000000000000000000000000abc",
+      requiredWei: BigInt(2),
+      availableWei: BigInt(1),
+    });
+    const { message, exit } = stageFailure("deploy", "build", gasErr);
+    expect(exit).toBe(EXIT_CODES.ONCHAIN_FAILED);
+    expect(message).toContain("Insufficient ETH for gas");
+    expect(message).not.toContain("no deployment was attempted");
   });
 
   it("each stage carries a distinct exit code", () => {

--- a/packages/cli/src/utils/__tests__/exitCodes.test.ts
+++ b/packages/cli/src/utils/__tests__/exitCodes.test.ts
@@ -1,21 +1,52 @@
 import { describe, expect, it } from "vitest";
-import { EXIT_CODES, errorMessage } from "../exitCodes";
+import { EXIT_CODES, errorMessage, stageFailure } from "../exitCodes";
 
-describe("deploy/upgrade exit codes", () => {
-  it("uses distinct, stable codes per failure stage", () => {
-    expect(EXIT_CODES.INVALID_INPUT).toBe(2);
-    expect(EXIT_CODES.BUILD_FAILED).toBe(3);
-    expect(EXIT_CODES.ONCHAIN_FAILED).toBe(4);
-    // All distinct.
-    expect(new Set(Object.values(EXIT_CODES)).size).toBe(3);
-  });
-
-  it("errorMessage extracts Error.message", () => {
+describe("errorMessage", () => {
+  it("extracts Error.message", () => {
     expect(errorMessage(new Error("boom"))).toBe("boom");
   });
 
-  it("errorMessage stringifies non-Error values", () => {
+  it("stringifies non-Error values", () => {
     expect(errorMessage("plain string")).toBe("plain string");
     expect(errorMessage(42)).toBe("42");
+  });
+});
+
+describe("stageFailure — maps a failed deploy/upgrade stage to message + exit code", () => {
+  it("invalid-input maps to exit 2 before any build", () => {
+    const { exit } = stageFailure("deploy", "invalid-input", "two flags missing");
+    expect(exit).toBe(EXIT_CODES.INVALID_INPUT);
+  });
+
+  it("build-stage failure maps to exit 3 and says no on-chain tx was attempted", () => {
+    const { message, exit } = stageFailure("deploy", "build", new Error("docker push 500"));
+    expect(exit).toBe(EXIT_CODES.BUILD_FAILED);
+    expect(message).toContain("Build/push failed");
+    expect(message).toContain("no deployment was attempted");
+    expect(message).toContain("docker push 500");
+  });
+
+  it("on-chain-stage failure maps to exit 4 and notes the image is already pushed", () => {
+    const { message, exit } = stageFailure("deploy", "onchain", new Error("nonce too low"));
+    expect(exit).toBe(EXIT_CODES.ONCHAIN_FAILED);
+    expect(message).toContain("On-chain deployment failed");
+    expect(message).toContain("nonce too low");
+    expect(message).toContain("re-running deploy will reuse it");
+  });
+
+  it("uses operation-specific wording for upgrade", () => {
+    const build = stageFailure("upgrade", "build", new Error("x"));
+    expect(build.message).toContain("no upgrade was attempted");
+
+    const onchain = stageFailure("upgrade", "onchain", new Error("x"));
+    expect(onchain.message).toContain("On-chain upgrade failed");
+    expect(onchain.message).toContain("re-running upgrade will reuse it");
+  });
+
+  it("each stage carries a distinct exit code", () => {
+    const exits = (["invalid-input", "build", "onchain"] as const).map(
+      (s) => stageFailure("deploy", s, "e").exit,
+    );
+    expect(new Set(exits).size).toBe(3);
   });
 });

--- a/packages/cli/src/utils/__tests__/exitCodes.test.ts
+++ b/packages/cli/src/utils/__tests__/exitCodes.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { EXIT_CODES, errorMessage } from "../exitCodes";
 
-describe("deploy/upgrade exit codes (RND-591)", () => {
+describe("deploy/upgrade exit codes", () => {
   it("uses distinct, stable codes per failure stage", () => {
     expect(EXIT_CODES.INVALID_INPUT).toBe(2);
     expect(EXIT_CODES.BUILD_FAILED).toBe(3);

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -372,4 +372,18 @@ describe("collectMissingRequiredInputs reports all missing at once", () => {
     const m = collectMissingRequiredInputs({}, "app-id");
     expect(m).toEqual([expect.stringMatching(/image source/)]);
   });
+  it("requires --image-ref as the push destination when building from --dockerfile", () => {
+    // A local Dockerfile build still needs somewhere to push the built image.
+    // Non-interactively, a missing --image-ref must be reported here (exit 2),
+    // not deferred to an interactive prompt that then throws as exit 1.
+    const m = collectMissingRequiredInputs({ dockerfile: "Dockerfile", name: "n" }, "name");
+    expect(m).toEqual([expect.stringMatching(/--image-ref/)]);
+  });
+  it("accepts --dockerfile together with --image-ref", () => {
+    const m = collectMissingRequiredInputs(
+      { dockerfile: "Dockerfile", imageRef: "r", name: "n" },
+      "name",
+    );
+    expect(m).toEqual([]);
+  });
 });

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -80,18 +80,18 @@ describe("prompts non-interactive regressions", () => {
       await expect(promptUseVerifiableBuild(true)).resolves.toBe(false);
     });
 
-    it("throws the 'Use --force' guidance when force is false in non-TTY mode", async () => {
+    // Post RND-568/569 merge: confirmWithDefault returns the default in non-TTY
+    // mode instead of throwing, so a verifiable-build confirm resolves to false
+    // (regular build) rather than erroring. RND-589-aligned: optional confirms
+    // never block a non-interactive run.
+    it("resolves to false (regular build) when force is false in non-TTY mode", async () => {
       process.stdin.isTTY = false;
-      await expect(promptUseVerifiableBuild(false)).rejects.toThrow(
-        /Cannot confirm "Build from verifiable source\?" in non-interactive mode\. Use --force/,
-      );
+      await expect(promptUseVerifiableBuild(false)).resolves.toBe(false);
     });
 
-    it("defaults force to false so existing callers still see the non-interactive error", async () => {
+    it("defaults force to false and still resolves to false in non-TTY mode", async () => {
       process.stdin.isTTY = false;
-      await expect(promptUseVerifiableBuild()).rejects.toThrow(
-        /Cannot confirm "Build from verifiable source\?" in non-interactive mode/,
-      );
+      await expect(promptUseVerifiableBuild()).resolves.toBe(false);
     });
   });
 });

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -80,10 +80,10 @@ describe("prompts non-interactive regressions", () => {
       await expect(promptUseVerifiableBuild(true)).resolves.toBe(false);
     });
 
-    // Post RND-568/569 merge: confirmWithDefault returns the default in non-TTY
-    // mode instead of throwing, so a verifiable-build confirm resolves to false
-    // (regular build) rather than erroring. RND-589-aligned: optional confirms
-    // never block a non-interactive run.
+    // confirmWithDefault returns the default in non-TTY mode instead of
+    // throwing, so a verifiable-build confirm resolves to false (regular
+    // build) rather than erroring. Optional confirms never block a
+    // non-interactive run.
     it("resolves to false (regular build) when force is false in non-TTY mode", async () => {
       process.stdin.isTTY = false;
       await expect(promptUseVerifiableBuild(false)).resolves.toBe(false);
@@ -97,12 +97,12 @@ describe("prompts non-interactive regressions", () => {
 });
 
 /**
- * RND-564 / RND-571: in non-interactive (non-TTY) mode, the optional deploy /
- * upgrade prompts must fall back to a safe default with a warning instead of
+ * In non-interactive (non-TTY) mode, the optional deploy / upgrade prompts
+ * must fall back to a safe default with a warning instead of
  * throwing "Cannot prompt in non-interactive mode". Required inputs that have
  * no safe default (e.g. --instance-type) must still error.
  */
-describe("non-interactive flag defaulting (RND-564)", () => {
+describe("non-interactive flag defaulting", () => {
   const origIsTTY = process.stdin.isTTY;
 
   afterEach(() => {
@@ -211,7 +211,7 @@ describe("non-interactive flag defaulting (RND-564)", () => {
       );
     });
 
-    // RND-589: deploy with no instance type defaults to g1-standard-2s in non-interactive mode.
+    // Deploy with no instance type defaults to g1-standard-2s in non-interactive mode.
     it("defaults to g1-standard-2s in non-interactive deploy when available", async () => {
       process.stdin.isTTY = false;
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -221,7 +221,7 @@ describe("non-interactive flag defaulting (RND-564)", () => {
       expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--instance-type.*g1-standard-2s/));
     });
 
-    // RND-589: upgrade reuses the currently pinned type (defaultSKU) instead of prompting.
+    // Upgrade reuses the currently pinned type (defaultSKU) instead of prompting.
     it("reuses defaultSKU (pinned type) in non-interactive upgrade", async () => {
       process.stdin.isTTY = false;
       vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -244,7 +244,7 @@ describe("non-interactive flag defaulting (RND-564)", () => {
   });
 });
 
-describe("isNonInteractive (RND-589 detection)", () => {
+describe("isNonInteractive detection", () => {
   const origTTY = process.stdin.isTTY;
   const origCI = process.env.CI;
   afterEach(() => {
@@ -275,7 +275,7 @@ describe("isNonInteractive (RND-589 detection)", () => {
   });
 });
 
-describe("collectMissingRequiredInputs (RND-589 all-at-once)", () => {
+describe("collectMissingRequiredInputs reports all missing at once", () => {
   it("returns [] when image source + name present", () => {
     expect(collectMissingRequiredInputs({ imageRef: "r", name: "n" }, "name")).toEqual([]);
   });

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -277,9 +277,7 @@ describe("isNonInteractive (RND-589 detection)", () => {
 
 describe("collectMissingRequiredInputs (RND-589 all-at-once)", () => {
   it("returns [] when image source + name present", () => {
-    expect(
-      collectMissingRequiredInputs({ imageRef: "r", name: "n" }, "name"),
-    ).toEqual([]);
+    expect(collectMissingRequiredInputs({ imageRef: "r", name: "n" }, "name")).toEqual([]);
   });
   it("lists both missing image source and name", () => {
     const m = collectMissingRequiredInputs({ verifiable: false }, "name");

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getEnvironmentInteractive, promptUseVerifiableBuild } from "../prompts";
+import fs from "fs";
+import {
+  getEnvironmentInteractive,
+  promptUseVerifiableBuild,
+  getDockerfileInteractive,
+  getEnvFileInteractive,
+  getLogSettingsInteractive,
+  getResourceUsageMonitoringInteractive,
+  getInstanceTypeInteractive,
+} from "../prompts";
 
 /**
  * Regression tests for two non-interactive mode bugs introduced in PR #126:
@@ -80,6 +89,130 @@ describe("prompts non-interactive regressions", () => {
       process.stdin.isTTY = false;
       await expect(promptUseVerifiableBuild()).rejects.toThrow(
         /Cannot confirm "Build from verifiable source\?" in non-interactive mode/,
+      );
+    });
+  });
+});
+
+/**
+ * RND-564 / RND-571: in non-interactive (non-TTY) mode, the optional deploy /
+ * upgrade prompts must fall back to a safe default with a warning instead of
+ * throwing "Cannot prompt in non-interactive mode". Required inputs that have
+ * no safe default (e.g. --instance-type) must still error.
+ */
+describe("non-interactive flag defaulting (RND-564)", () => {
+  const origIsTTY = process.stdin.isTTY;
+
+  afterEach(() => {
+    process.stdin.isTTY = origIsTTY;
+    vi.restoreAllMocks();
+  });
+
+  describe("getEnvFileInteractive", () => {
+    it("defaults to no env file in non-TTY mode when none is found", async () => {
+      process.stdin.isTTY = false;
+      // No explicit path, and no auto-detected .env on disk.
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await expect(getEnvFileInteractive(undefined)).resolves.toBe("");
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--env-file.*no env file/));
+    });
+
+    it("still returns an explicitly provided, existing env file in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => p === "custom.env");
+      await expect(getEnvFileInteractive("custom.env")).resolves.toBe("custom.env");
+    });
+  });
+
+  describe("getLogSettingsInteractive", () => {
+    it("defaults to private logs in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await expect(getLogSettingsInteractive(undefined)).resolves.toEqual({
+        logRedirect: "always",
+        publicLogs: false,
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--log-visibility.*private/));
+    });
+
+    it("never silently defaults to public in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const settings = await getLogSettingsInteractive(undefined);
+      expect(settings.publicLogs).toBe(false);
+    });
+
+    it("honors an explicit --log-visibility value regardless of TTY", async () => {
+      process.stdin.isTTY = false;
+      await expect(getLogSettingsInteractive("public")).resolves.toEqual({
+        logRedirect: "always",
+        publicLogs: true,
+      });
+    });
+  });
+
+  describe("getResourceUsageMonitoringInteractive", () => {
+    it("defaults to disable in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await expect(getResourceUsageMonitoringInteractive(undefined)).resolves.toBe("disable");
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(/--resource-usage-monitoring.*disable/),
+      );
+    });
+
+    it("honors an explicit value regardless of TTY", async () => {
+      process.stdin.isTTY = false;
+      await expect(getResourceUsageMonitoringInteractive("enable")).resolves.toBe("enable");
+    });
+  });
+
+  describe("getDockerfileInteractive", () => {
+    it("returns '' (deploy existing image) when no Dockerfile exists, even in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+      await expect(getDockerfileInteractive(undefined)).resolves.toBe("");
+    });
+
+    it("defaults to building the discovered Dockerfile in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      vi.spyOn(fs, "existsSync").mockReturnValue(true);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await getDockerfileInteractive(undefined);
+      expect(result).toMatch(/Dockerfile$/);
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--dockerfile.*build from/));
+    });
+
+    it("returns an explicitly provided Dockerfile path verbatim", async () => {
+      process.stdin.isTTY = false;
+      await expect(getDockerfileInteractive("./custom/Dockerfile")).resolves.toBe(
+        "./custom/Dockerfile",
+      );
+    });
+  });
+
+  describe("getInstanceTypeInteractive", () => {
+    const types = [
+      { sku: "g1-standard-2s", friendly_name: "Standard 2s", description: "2 vCPU, SEV-SNP" },
+      { sku: "g1-standard-4t", friendly_name: "Standard 4t", description: "4 vCPU, TDX" },
+    ];
+
+    it("still errors in non-TTY mode when no instance type is provided (no safe default)", async () => {
+      process.stdin.isTTY = false;
+      await expect(getInstanceTypeInteractive(undefined, "", types)).rejects.toThrow(
+        /Cannot prompt in non-interactive mode.*--instance-type/,
+      );
+    });
+
+    it("returns an explicitly provided, valid instance type in non-TTY mode", async () => {
+      process.stdin.isTTY = false;
+      await expect(getInstanceTypeInteractive("g1-standard-2s", "", types)).resolves.toBe(
+        "g1-standard-2s",
       );
     });
   });

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -22,11 +22,11 @@ vi.mock("@inquirer/prompts", () => ({
 import {
   getEnvironmentInteractive,
   promptUseVerifiableBuild,
-  getDockerfileInteractive,
-  getEnvFileInteractive,
-  getLogSettingsInteractive,
-  getResourceUsageMonitoringInteractive,
-  getInstanceTypeInteractive,
+  getDockerfile,
+  getEnvFile,
+  getLogSettings,
+  getResourceUsageMonitoring,
+  getInstanceType,
   isNonInteractive,
   collectMissingRequiredInputs,
 } from "../prompts";
@@ -129,30 +129,30 @@ describe("non-interactive flag defaulting", () => {
     vi.restoreAllMocks();
   });
 
-  describe("getEnvFileInteractive", () => {
+  describe("getEnvFile", () => {
     it("defaults to no env file in non-TTY mode when none is found", async () => {
       process.stdin.isTTY = false;
       // No explicit path, and no auto-detected .env on disk.
       vi.spyOn(fs, "existsSync").mockReturnValue(false);
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await expect(getEnvFileInteractive(undefined, true)).resolves.toBe("");
+      await expect(getEnvFile(undefined, true)).resolves.toBe("");
       expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--env-file.*no env file/));
     });
 
     it("still returns an explicitly provided, existing env file in non-TTY mode", async () => {
       process.stdin.isTTY = false;
       vi.spyOn(fs, "existsSync").mockImplementation((p) => p === "custom.env");
-      await expect(getEnvFileInteractive("custom.env")).resolves.toBe("custom.env");
+      await expect(getEnvFile("custom.env")).resolves.toBe("custom.env");
     });
   });
 
-  describe("getLogSettingsInteractive", () => {
+  describe("getLogSettings", () => {
     it("defaults to private logs in non-TTY mode", async () => {
       process.stdin.isTTY = false;
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await expect(getLogSettingsInteractive(undefined, true)).resolves.toEqual({
+      await expect(getLogSettings(undefined, true)).resolves.toEqual({
         logRedirect: "always",
         publicLogs: false,
       });
@@ -162,25 +162,25 @@ describe("non-interactive flag defaulting", () => {
     it("never silently defaults to public in non-TTY mode", async () => {
       process.stdin.isTTY = false;
       vi.spyOn(console, "warn").mockImplementation(() => {});
-      const settings = await getLogSettingsInteractive(undefined, true);
+      const settings = await getLogSettings(undefined, true);
       expect(settings.publicLogs).toBe(false);
     });
 
     it("honors an explicit --log-visibility value regardless of TTY", async () => {
       process.stdin.isTTY = false;
-      await expect(getLogSettingsInteractive("public")).resolves.toEqual({
+      await expect(getLogSettings("public")).resolves.toEqual({
         logRedirect: "always",
         publicLogs: true,
       });
     });
   });
 
-  describe("getResourceUsageMonitoringInteractive", () => {
+  describe("getResourceUsageMonitoring", () => {
     it("defaults to disable in non-TTY mode", async () => {
       process.stdin.isTTY = false;
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await expect(getResourceUsageMonitoringInteractive(undefined, true)).resolves.toBe("disable");
+      await expect(getResourceUsageMonitoring(undefined, true)).resolves.toBe("disable");
       expect(warn).toHaveBeenCalledWith(
         expect.stringMatching(/--resource-usage-monitoring.*disable/),
       );
@@ -188,15 +188,15 @@ describe("non-interactive flag defaulting", () => {
 
     it("honors an explicit value regardless of TTY", async () => {
       process.stdin.isTTY = false;
-      await expect(getResourceUsageMonitoringInteractive("enable")).resolves.toBe("enable");
+      await expect(getResourceUsageMonitoring("enable")).resolves.toBe("enable");
     });
   });
 
-  describe("getDockerfileInteractive", () => {
+  describe("getDockerfile", () => {
     it("returns '' (deploy existing image) when no Dockerfile exists, even in non-TTY mode", async () => {
       process.stdin.isTTY = false;
       vi.spyOn(fs, "existsSync").mockReturnValue(false);
-      await expect(getDockerfileInteractive(undefined)).resolves.toBe("");
+      await expect(getDockerfile(undefined)).resolves.toBe("");
     });
 
     it("defaults to building the discovered Dockerfile in non-TTY mode", async () => {
@@ -204,20 +204,18 @@ describe("non-interactive flag defaulting", () => {
       vi.spyOn(fs, "existsSync").mockReturnValue(true);
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      const result = await getDockerfileInteractive(undefined, true);
+      const result = await getDockerfile(undefined, true);
       expect(result).toMatch(/Dockerfile$/);
       expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--dockerfile.*build from/));
     });
 
     it("returns an explicitly provided Dockerfile path verbatim", async () => {
       process.stdin.isTTY = false;
-      await expect(getDockerfileInteractive("./custom/Dockerfile")).resolves.toBe(
-        "./custom/Dockerfile",
-      );
+      await expect(getDockerfile("./custom/Dockerfile")).resolves.toBe("./custom/Dockerfile");
     });
   });
 
-  describe("getInstanceTypeInteractive", () => {
+  describe("getInstanceType", () => {
     const types = [
       { sku: "g1-standard-2s", friendly_name: "Standard 2s", description: "2 vCPU, SEV-SNP" },
       { sku: "g1-standard-4t", friendly_name: "Standard 4t", description: "4 vCPU, TDX" },
@@ -225,18 +223,14 @@ describe("non-interactive flag defaulting", () => {
 
     it("returns an explicitly provided, valid instance type in non-TTY mode", async () => {
       process.stdin.isTTY = false;
-      await expect(getInstanceTypeInteractive("g1-standard-2s", "", types)).resolves.toBe(
-        "g1-standard-2s",
-      );
+      await expect(getInstanceType("g1-standard-2s", "", types)).resolves.toBe("g1-standard-2s");
     });
 
     // Deploy with no instance type defaults to g1-standard-2s in non-interactive mode.
     it("defaults to g1-standard-2s in non-interactive deploy when available", async () => {
       process.stdin.isTTY = false;
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-      await expect(getInstanceTypeInteractive(undefined, "", types, true)).resolves.toBe(
-        "g1-standard-2s",
-      );
+      await expect(getInstanceType(undefined, "", types, true)).resolves.toBe("g1-standard-2s");
       expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--instance-type.*g1-standard-2s/));
     });
 
@@ -244,15 +238,15 @@ describe("non-interactive flag defaulting", () => {
     it("reuses defaultSKU (pinned type) in non-interactive upgrade", async () => {
       process.stdin.isTTY = false;
       vi.spyOn(console, "warn").mockImplementation(() => {});
-      await expect(
-        getInstanceTypeInteractive(undefined, "g1-standard-4t", types, true),
-      ).resolves.toBe("g1-standard-4t");
+      await expect(getInstanceType(undefined, "g1-standard-4t", types, true)).resolves.toBe(
+        "g1-standard-4t",
+      );
     });
 
     it("errors in non-interactive when the default SKU is not offered", async () => {
       process.stdin.isTTY = false;
       await expect(
-        getInstanceTypeInteractive(
+        getInstanceType(
           undefined,
           "",
           [{ sku: "g1-micro-1v", friendly_name: "m", description: "" }],
@@ -286,34 +280,34 @@ describe("optional-input helpers honor injected nonInteractive on a TTY", () => 
     vi.restoreAllMocks();
   });
 
-  it("getEnvFileInteractive defaults to no env file", async () => {
+  it("getEnvFile defaults to no env file", async () => {
     vi.spyOn(fs, "existsSync").mockReturnValue(false);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await expect(getEnvFileInteractive(undefined, true)).resolves.toBe("");
+    await expect(getEnvFile(undefined, true)).resolves.toBe("");
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--env-file.*no env file/));
   });
 
-  it("getLogSettingsInteractive defaults to private logs", async () => {
+  it("getLogSettings defaults to private logs", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await expect(getLogSettingsInteractive(undefined, true)).resolves.toEqual({
+    await expect(getLogSettings(undefined, true)).resolves.toEqual({
       logRedirect: "always",
       publicLogs: false,
     });
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--log-visibility.*private/));
   });
 
-  it("getResourceUsageMonitoringInteractive defaults to disable", async () => {
+  it("getResourceUsageMonitoring defaults to disable", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    await expect(getResourceUsageMonitoringInteractive(undefined, true)).resolves.toBe("disable");
+    await expect(getResourceUsageMonitoring(undefined, true)).resolves.toBe("disable");
     expect(warn).toHaveBeenCalledWith(
       expect.stringMatching(/--resource-usage-monitoring.*disable/),
     );
   });
 
-  it("getDockerfileInteractive defaults to building the discovered Dockerfile", async () => {
+  it("getDockerfile defaults to building the discovered Dockerfile", async () => {
     vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const result = await getDockerfileInteractive(undefined, true);
+    const result = await getDockerfile(undefined, true);
     expect(result).toMatch(/Dockerfile$/);
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--dockerfile.*build from/));
   });
@@ -323,9 +317,7 @@ describe("optional-input helpers honor injected nonInteractive on a TTY", () => 
     // (mocked) prompt rather than silently defaulting. Proves the boolean is
     // actually driving the branch, not being ignored.
     vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    await expect(getLogSettingsInteractive(undefined, false)).rejects.toThrow(
-      /unexpected interactive/,
-    );
+    await expect(getLogSettings(undefined, false)).rejects.toThrow(/unexpected interactive/);
   });
 });
 

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -1,5 +1,24 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "fs";
+
+// Any helper that falls through to an interactive prompt is a bug in these
+// tests' scenarios (we always run with a non-interactive intent). Make that
+// fail loudly and deterministically instead of hanging on real stdin.
+vi.mock("@inquirer/prompts", () => ({
+  select: vi.fn(async () => {
+    throw new Error("unexpected interactive select()");
+  }),
+  input: vi.fn(async () => {
+    throw new Error("unexpected interactive input()");
+  }),
+  password: vi.fn(async () => {
+    throw new Error("unexpected interactive password()");
+  }),
+  confirm: vi.fn(async () => {
+    throw new Error("unexpected interactive confirm()");
+  }),
+}));
+
 import {
   getEnvironmentInteractive,
   promptUseVerifiableBuild,
@@ -117,7 +136,7 @@ describe("non-interactive flag defaulting", () => {
       vi.spyOn(fs, "existsSync").mockReturnValue(false);
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await expect(getEnvFileInteractive(undefined)).resolves.toBe("");
+      await expect(getEnvFileInteractive(undefined, true)).resolves.toBe("");
       expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--env-file.*no env file/));
     });
 
@@ -133,7 +152,7 @@ describe("non-interactive flag defaulting", () => {
       process.stdin.isTTY = false;
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await expect(getLogSettingsInteractive(undefined)).resolves.toEqual({
+      await expect(getLogSettingsInteractive(undefined, true)).resolves.toEqual({
         logRedirect: "always",
         publicLogs: false,
       });
@@ -143,7 +162,7 @@ describe("non-interactive flag defaulting", () => {
     it("never silently defaults to public in non-TTY mode", async () => {
       process.stdin.isTTY = false;
       vi.spyOn(console, "warn").mockImplementation(() => {});
-      const settings = await getLogSettingsInteractive(undefined);
+      const settings = await getLogSettingsInteractive(undefined, true);
       expect(settings.publicLogs).toBe(false);
     });
 
@@ -161,7 +180,7 @@ describe("non-interactive flag defaulting", () => {
       process.stdin.isTTY = false;
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      await expect(getResourceUsageMonitoringInteractive(undefined)).resolves.toBe("disable");
+      await expect(getResourceUsageMonitoringInteractive(undefined, true)).resolves.toBe("disable");
       expect(warn).toHaveBeenCalledWith(
         expect.stringMatching(/--resource-usage-monitoring.*disable/),
       );
@@ -185,7 +204,7 @@ describe("non-interactive flag defaulting", () => {
       vi.spyOn(fs, "existsSync").mockReturnValue(true);
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-      const result = await getDockerfileInteractive(undefined);
+      const result = await getDockerfileInteractive(undefined, true);
       expect(result).toMatch(/Dockerfile$/);
       expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--dockerfile.*build from/));
     });
@@ -241,6 +260,72 @@ describe("non-interactive flag defaulting", () => {
         ),
       ).rejects.toThrow(/instance-type/);
     });
+  });
+});
+
+/**
+ * The optional-input helpers must honor an injected non-interactive decision,
+ * not re-derive it from process.stdin/CI internally. This is what lets
+ * `--non-interactive` work on a real TTY (where isTTY is true and CI is unset):
+ * the command resolves isNonInteractive(flags) once and threads the boolean
+ * down. Each test below runs on a TTY with CI unset — so a helper that ignores
+ * the injected flag would fall through to a (mocked, throwing) prompt.
+ */
+describe("optional-input helpers honor injected nonInteractive on a TTY", () => {
+  const origIsTTY = process.stdin.isTTY;
+  const origCI = process.env.CI;
+
+  beforeEach(() => {
+    process.stdin.isTTY = true;
+    delete process.env.CI;
+  });
+  afterEach(() => {
+    process.stdin.isTTY = origIsTTY;
+    if (origCI === undefined) delete process.env.CI;
+    else process.env.CI = origCI;
+    vi.restoreAllMocks();
+  });
+
+  it("getEnvFileInteractive defaults to no env file", async () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(getEnvFileInteractive(undefined, true)).resolves.toBe("");
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--env-file.*no env file/));
+  });
+
+  it("getLogSettingsInteractive defaults to private logs", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(getLogSettingsInteractive(undefined, true)).resolves.toEqual({
+      logRedirect: "always",
+      publicLogs: false,
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--log-visibility.*private/));
+  });
+
+  it("getResourceUsageMonitoringInteractive defaults to disable", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(getResourceUsageMonitoringInteractive(undefined, true)).resolves.toBe("disable");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringMatching(/--resource-usage-monitoring.*disable/),
+    );
+  });
+
+  it("getDockerfileInteractive defaults to building the discovered Dockerfile", async () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await getDockerfileInteractive(undefined, true);
+    expect(result).toMatch(/Dockerfile$/);
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--dockerfile.*build from/));
+  });
+
+  it("the same helpers still prompt on a TTY when nonInteractive is false", async () => {
+    // Sanity: when the injected decision is interactive, the helper reaches the
+    // (mocked) prompt rather than silently defaulting. Proves the boolean is
+    // actually driving the branch, not being ignored.
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    await expect(getLogSettingsInteractive(undefined, false)).rejects.toThrow(
+      /unexpected interactive/,
+    );
   });
 });
 

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -8,6 +8,8 @@ import {
   getLogSettingsInteractive,
   getResourceUsageMonitoringInteractive,
   getInstanceTypeInteractive,
+  isNonInteractive,
+  collectMissingRequiredInputs,
 } from "../prompts";
 
 /**
@@ -215,5 +217,60 @@ describe("non-interactive flag defaulting (RND-564)", () => {
         "g1-standard-2s",
       );
     });
+  });
+});
+
+describe("isNonInteractive (RND-589 detection)", () => {
+  const origTTY = process.stdin.isTTY;
+  const origCI = process.env.CI;
+  afterEach(() => {
+    process.stdin.isTTY = origTTY;
+    if (origCI === undefined) delete process.env.CI;
+    else process.env.CI = origCI;
+  });
+
+  it("true when --non-interactive flag is set, even on a TTY", () => {
+    process.stdin.isTTY = true;
+    delete process.env.CI;
+    expect(isNonInteractive({ "non-interactive": true })).toBe(true);
+  });
+  it("true when CI=true, even on a TTY", () => {
+    process.stdin.isTTY = true;
+    process.env.CI = "true";
+    expect(isNonInteractive()).toBe(true);
+  });
+  it("true when no TTY", () => {
+    process.stdin.isTTY = false;
+    delete process.env.CI;
+    expect(isNonInteractive()).toBe(true);
+  });
+  it("false on a TTY with no CI and no flag", () => {
+    process.stdin.isTTY = true;
+    delete process.env.CI;
+    expect(isNonInteractive()).toBe(false);
+  });
+});
+
+describe("collectMissingRequiredInputs (RND-589 all-at-once)", () => {
+  it("returns [] when image source + name present", () => {
+    expect(
+      collectMissingRequiredInputs({ imageRef: "r", name: "n" }, "name"),
+    ).toEqual([]);
+  });
+  it("lists both missing image source and name", () => {
+    const m = collectMissingRequiredInputs({ verifiable: false }, "name");
+    expect(m.join(" ")).toMatch(/image source/);
+    expect(m.join(" ")).toMatch(/--name/);
+  });
+  it("accepts verifiable git source as image source", () => {
+    const m = collectMissingRequiredInputs(
+      { verifiable: true, repo: "x", commit: "y", name: "n" },
+      "name",
+    );
+    expect(m).toEqual([]);
+  });
+  it("reports only the image source for upgrade (app-id handled at call site)", () => {
+    const m = collectMissingRequiredInputs({}, "app-id");
+    expect(m).toEqual([expect.stringMatching(/image source/)]);
   });
 });

--- a/packages/cli/src/utils/__tests__/prompts.test.ts
+++ b/packages/cli/src/utils/__tests__/prompts.test.ts
@@ -204,18 +204,42 @@ describe("non-interactive flag defaulting (RND-564)", () => {
       { sku: "g1-standard-4t", friendly_name: "Standard 4t", description: "4 vCPU, TDX" },
     ];
 
-    it("still errors in non-TTY mode when no instance type is provided (no safe default)", async () => {
-      process.stdin.isTTY = false;
-      await expect(getInstanceTypeInteractive(undefined, "", types)).rejects.toThrow(
-        /Cannot prompt in non-interactive mode.*--instance-type/,
-      );
-    });
-
     it("returns an explicitly provided, valid instance type in non-TTY mode", async () => {
       process.stdin.isTTY = false;
       await expect(getInstanceTypeInteractive("g1-standard-2s", "", types)).resolves.toBe(
         "g1-standard-2s",
       );
+    });
+
+    // RND-589: deploy with no instance type defaults to g1-standard-2s in non-interactive mode.
+    it("defaults to g1-standard-2s in non-interactive deploy when available", async () => {
+      process.stdin.isTTY = false;
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await expect(getInstanceTypeInteractive(undefined, "", types, true)).resolves.toBe(
+        "g1-standard-2s",
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/--instance-type.*g1-standard-2s/));
+    });
+
+    // RND-589: upgrade reuses the currently pinned type (defaultSKU) instead of prompting.
+    it("reuses defaultSKU (pinned type) in non-interactive upgrade", async () => {
+      process.stdin.isTTY = false;
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      await expect(
+        getInstanceTypeInteractive(undefined, "g1-standard-4t", types, true),
+      ).resolves.toBe("g1-standard-4t");
+    });
+
+    it("errors in non-interactive when the default SKU is not offered", async () => {
+      process.stdin.isTTY = false;
+      await expect(
+        getInstanceTypeInteractive(
+          undefined,
+          "",
+          [{ sku: "g1-micro-1v", friendly_name: "m", description: "" }],
+          true,
+        ),
+      ).rejects.toThrow(/instance-type/);
     });
   });
 });

--- a/packages/cli/src/utils/dockerhub.ts
+++ b/packages/cli/src/utils/dockerhub.ts
@@ -102,5 +102,93 @@ export async function resolveDockerHubImageDigest(imageRef: string): Promise<str
   if (!/^sha256:[0-9a-f]{64}$/i.test(digest)) {
     throw new Error(`Unexpected digest format from Docker registry: ${digest}`);
   }
+
+  // RND-597: a prebuilt image ref must contain a linux/amd64 image, or it will
+  // deploy and then crash on first request in the TEE. The digest fetch above
+  // does not look at architecture, so verify it explicitly here.
+  await assertImageHasAmd64(owner, repo, tag, token, imageRef);
+
   return digest;
+}
+
+const AMD64_ACCEPT = [
+  "application/vnd.oci.image.index.v1+json",
+  "application/vnd.docker.distribution.manifest.list.v2+json",
+  "application/vnd.oci.image.manifest.v1+json",
+  "application/vnd.docker.distribution.manifest.v2+json",
+].join(", ");
+
+/**
+ * Verify a Docker Hub tag exposes a linux/amd64 image (RND-597).
+ *
+ * - Multi-platform (manifest list / OCI index): require a linux/amd64 entry.
+ * - Single-platform: read the config blob's `architecture`/`os` and require
+ *   linux/amd64.
+ *
+ * Throws a remediation error otherwise.
+ */
+async function assertImageHasAmd64(
+  owner: string,
+  repo: string,
+  tag: string,
+  token: string,
+  imageRef: string,
+): Promise<void> {
+  const base = `https://registry-1.docker.io/v2/${owner}/${repo}`;
+  const headers = { Authorization: `Bearer ${token}`, Accept: AMD64_ACCEPT };
+
+  const res = await fetch(`${base}/manifests/${encodeURIComponent(tag)}`, { headers });
+  if (!res.ok) {
+    const body = await safeReadText(res);
+    throw new Error(
+      `Failed to read manifest for ${imageRef} (${res.status}): ${body || res.statusText}`,
+    );
+  }
+  const manifest = (await res.json()) as {
+    manifests?: Array<{ platform?: { os?: string; architecture?: string } }>;
+    config?: { digest?: string };
+    architecture?: string;
+    os?: string;
+  };
+
+  const isAmd64 = (os?: string, arch?: string) => os === "linux" && arch === "amd64";
+
+  // Multi-platform: scan the index entries.
+  if (Array.isArray(manifest.manifests) && manifest.manifests.length > 0) {
+    const platforms = manifest.manifests.map((m) =>
+      m.platform ? `${m.platform.os}/${m.platform.architecture}` : "unknown",
+    );
+    if (manifest.manifests.some((m) => isAmd64(m.platform?.os, m.platform?.architecture))) {
+      return;
+    }
+    throw amd64Error(imageRef, platforms);
+  }
+
+  // Single-platform: the architecture lives in the config blob, not the manifest.
+  const configDigest = manifest.config?.digest;
+  if (!configDigest) {
+    throw amd64Error(imageRef, ["unknown (no platform info in manifest)"]);
+  }
+  const cfgRes = await fetch(`${base}/blobs/${configDigest}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!cfgRes.ok) {
+    throw amd64Error(imageRef, ["unknown (could not read image config)"]);
+  }
+  const cfg = (await cfgRes.json()) as { architecture?: string; os?: string };
+  if (isAmd64(cfg.os, cfg.architecture)) {
+    return;
+  }
+  throw amd64Error(imageRef, [`${cfg.os ?? "unknown"}/${cfg.architecture ?? "unknown"}`]);
+}
+
+function amd64Error(imageRef: string, platforms: string[]): Error {
+  return new Error(
+    `ecloud requires linux/amd64 images for TEE deployment.\n\n` +
+      `Image: ${imageRef}\n` +
+      `Found platform(s): ${platforms.join(", ")}\n` +
+      `Required platform: linux/amd64\n\n` +
+      `To fix: rebuild for linux/amd64 (e.g. docker buildx build --platform linux/amd64 ... --push), ` +
+      `or use a verifiable build (--verifiable --repo <repo> --commit <sha>), which builds server-side.`,
+  );
 }

--- a/packages/cli/src/utils/dockerhub.ts
+++ b/packages/cli/src/utils/dockerhub.ts
@@ -103,7 +103,7 @@ export async function resolveDockerHubImageDigest(imageRef: string): Promise<str
     throw new Error(`Unexpected digest format from Docker registry: ${digest}`);
   }
 
-  // RND-597: a prebuilt image ref must contain a linux/amd64 image, or it will
+  // A prebuilt image ref must contain a linux/amd64 image, or it will
   // deploy and then crash on first request in the TEE. The digest fetch above
   // does not look at architecture, so verify it explicitly here.
   await assertImageHasAmd64(owner, repo, tag, token, imageRef);
@@ -119,7 +119,7 @@ const AMD64_ACCEPT = [
 ].join(", ");
 
 /**
- * Verify a Docker Hub tag exposes a linux/amd64 image (RND-597).
+ * Verify a Docker Hub tag exposes a linux/amd64 image.
  *
  * - Multi-platform (manifest list / OCI index): require a linux/amd64 entry.
  * - Single-platform: read the config blob's `architecture`/`os` and require

--- a/packages/cli/src/utils/exitCodes.ts
+++ b/packages/cli/src/utils/exitCodes.ts
@@ -1,3 +1,5 @@
+import { InsufficientGasError } from "@layr-labs/ecloud-sdk";
+
 /**
  * Distinct process exit codes for deploy/upgrade so a caller (CI, agent) keying
  * off exit status can tell *which stage* failed.
@@ -42,6 +44,12 @@ export type DeployStage = "invalid-input" | "build" | "onchain";
  *
  * - build:   no image was produced, so no on-chain tx was attempted (exit 3).
  * - onchain: the image is already built+pushed; a re-run reuses it (exit 4).
+ *
+ * Exception: the gas pre-flight (`assertSufficientGas`) runs inside prepare*()
+ * AFTER the image is built and pushed, so an `InsufficientGasError` surfaces
+ * through the build try/catch. The image already exists, so it is reclassified
+ * as an on-chain-readiness failure (exit 4) rather than a build failure (exit
+ * 3) — reporting "no <op> was attempted" would be wrong and misleading.
  */
 export function stageFailure(
   operation: DeployOperation,
@@ -49,6 +57,13 @@ export function stageFailure(
   err: unknown,
 ): { message: string; exit: DeployStageExitCode } {
   const noun = operation === "deploy" ? "deployment" : "upgrade";
+
+  // The image is already pushed by the time gas is checked, so treat an
+  // insufficient-gas failure as on-chain regardless of which stage caught it.
+  if (err instanceof InsufficientGasError) {
+    stage = "onchain";
+  }
+
   switch (stage) {
     case "invalid-input":
       return { message: errorMessage(err), exit: EXIT_CODES.INVALID_INPUT };

--- a/packages/cli/src/utils/exitCodes.ts
+++ b/packages/cli/src/utils/exitCodes.ts
@@ -27,3 +27,42 @@ export function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
 }
+
+/** The operation a failure occurred under (drives the user-facing wording). */
+export type DeployOperation = "deploy" | "upgrade";
+
+/** Which stage of deploy/upgrade failed (drives the exit code). */
+export type DeployStage = "invalid-input" | "build" | "onchain";
+
+/**
+ * Map a failed deploy/upgrade stage to a user-facing message and the matching
+ * process exit code, so a caller (CI, agent) keying off exit status can tell
+ * *which stage* failed. Pure — the command layer feeds the result straight to
+ * `this.error(message, { exit })`.
+ *
+ * - build:   no image was produced, so no on-chain tx was attempted (exit 3).
+ * - onchain: the image is already built+pushed; a re-run reuses it (exit 4).
+ */
+export function stageFailure(
+  operation: DeployOperation,
+  stage: DeployStage,
+  err: unknown,
+): { message: string; exit: DeployStageExitCode } {
+  const noun = operation === "deploy" ? "deployment" : "upgrade";
+  switch (stage) {
+    case "invalid-input":
+      return { message: errorMessage(err), exit: EXIT_CODES.INVALID_INPUT };
+    case "build":
+      return {
+        message: `Build/push failed (no ${noun} was attempted): ${errorMessage(err)}`,
+        exit: EXIT_CODES.BUILD_FAILED,
+      };
+    case "onchain":
+      return {
+        message:
+          `On-chain ${noun} failed after the image was built and pushed: ${errorMessage(err)}\n` +
+          `The image is already pushed — re-running ${operation} will reuse it.`,
+        exit: EXIT_CODES.ONCHAIN_FAILED,
+      };
+  }
+}

--- a/packages/cli/src/utils/exitCodes.ts
+++ b/packages/cli/src/utils/exitCodes.ts
@@ -1,0 +1,26 @@
+/**
+ * Distinct process exit codes for deploy/upgrade so a caller (CI, agent) keying
+ * off exit status can tell *which stage* failed (RND-591).
+ *
+ * A ~7-minute build that succeeds and then fails on-chain must be
+ * distinguishable from a build that never produced an image.
+ *
+ *   1  generic / unclassified error (oclif default)
+ *   2  invalid or missing input — fails before any build
+ *   3  build/push failed — no on-chain transaction was attempted
+ *   4  build/push succeeded but the on-chain transaction failed
+ *      (the image is already built+pushed; a re-run reuses it)
+ */
+export const EXIT_CODES = {
+  INVALID_INPUT: 2,
+  BUILD_FAILED: 3,
+  ONCHAIN_FAILED: 4,
+} as const;
+
+export type DeployStageExitCode = (typeof EXIT_CODES)[keyof typeof EXIT_CODES];
+
+/** Extract a human-readable message from an unknown thrown value. */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/cli/src/utils/exitCodes.ts
+++ b/packages/cli/src/utils/exitCodes.ts
@@ -5,7 +5,10 @@
  * A ~7-minute build that succeeds and then fails on-chain must be
  * distinguishable from a build that never produced an image.
  *
- *   1  generic / unclassified error (oclif default)
+ * Exit code 1 is intentionally NOT defined here: it is oclif's default for any
+ * unclassified error (a plain `this.error(msg)` with no `exit` option). The
+ * codes below are the stage-specific ones we assign on top of that baseline.
+ *
  *   2  invalid or missing input — fails before any build
  *   3  build/push failed — no on-chain transaction was attempted
  *   4  build/push succeeded but the on-chain transaction failed

--- a/packages/cli/src/utils/exitCodes.ts
+++ b/packages/cli/src/utils/exitCodes.ts
@@ -1,6 +1,6 @@
 /**
  * Distinct process exit codes for deploy/upgrade so a caller (CI, agent) keying
- * off exit status can tell *which stage* failed (RND-591).
+ * off exit status can tell *which stage* failed.
  *
  * A ~7-minute build that succeeds and then fails on-chain must be
  * distinguishable from a build that never produced an image.

--- a/packages/cli/src/utils/instanceTypes.ts
+++ b/packages/cli/src/utils/instanceTypes.ts
@@ -1,0 +1,40 @@
+import { UserApiClient } from "@layr-labs/ecloud-sdk";
+import { createViemClients } from "./viemClients";
+import { getClientId } from "./version";
+import type { SkuInfo } from "./prompts";
+
+/**
+ * Fetch the instance types (SKUs) offered by the backend for an environment.
+ *
+ * Best-effort: on any failure (network, auth, empty list) this warns and returns
+ * a single safe fallback SKU rather than aborting, so deploy/upgrade can still
+ * proceed with a sensible default.
+ */
+export async function fetchAvailableInstanceTypes(
+  environment: string,
+  environmentConfig: any,
+  privateKey: string,
+  rpcUrl: string,
+): Promise<SkuInfo[]> {
+  try {
+    const { publicClient, walletClient } = createViemClients({
+      privateKey,
+      rpcUrl,
+      environment,
+    });
+    const userApiClient = new UserApiClient(environmentConfig, walletClient, publicClient, {
+      clientId: getClientId(),
+    });
+
+    const skuList = await userApiClient.getSKUs();
+    if (skuList.skus.length === 0) {
+      throw new Error("No instance types available from server");
+    }
+
+    return skuList.skus;
+  } catch (err: any) {
+    console.warn(`Failed to fetch instance types: ${err.message}`);
+    // Return a default fallback
+    return [{ sku: "g1-standard-4t", description: "4 vCPUs, 16 GB memory, TDX" }];
+  }
+}

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -63,15 +63,21 @@ function ensureInteractive(missingFlagHint: string): void {
 }
 
 /**
- * True when there is no attached TTY (CI, scripted use, agents).
+ * True when the CLI should run without interactive prompts.
+ *
+ * Precedence: an explicit `--non-interactive` flag, then `CI=true`, then the
+ * absence of a TTY. `isTTY` alone is unreliable in pipes/CI, so the flag and CI
+ * env give callers (agents, scripts) a deterministic signal.
  *
  * The optional deploy/upgrade prompts (env file, log visibility, resource-usage
- * monitoring, Dockerfile-vs-existing-image) all have a safe default, so rather
- * than throwing via `ensureInteractive` they fall back to that default and log
- * what was chosen. Required inputs with no safe default (image source,
- * instance type, app name/id) keep calling `ensureInteractive` and still error.
+ * monitoring, Dockerfile-vs-existing-image, instance type) all have a safe
+ * default, so rather than throwing via `ensureInteractive` they fall back to
+ * that default and log what was chosen. Required inputs with no safe default
+ * (image source, app name/id) are reported all-at-once by the command layer.
  */
-function isNonInteractive(): boolean {
+export function isNonInteractive(flags?: { "non-interactive"?: boolean }): boolean {
+  if (flags?.["non-interactive"]) return true;
+  if (process.env.CI === "true") return true;
   return !process.stdin.isTTY;
 }
 
@@ -82,6 +88,46 @@ function isNonInteractive(): boolean {
  */
 function warnDefaulted(flagHint: string, chosen: string): void {
   console.warn(`Warning: ${flagHint} not set in non-interactive mode; defaulting to ${chosen}.`);
+}
+
+/** The set of required deploy/upgrade inputs that have no safe default. */
+export interface RequiredInputState {
+  imageRef?: string;
+  dockerfile?: string;
+  verifiable?: boolean;
+  repo?: string;
+  commit?: string;
+  name?: string;
+}
+
+/**
+ * Collect ALL missing required deploy/upgrade inputs for non-interactive mode,
+ * so the caller can report them in one error instead of one prompt at a time.
+ *
+ * Covers the image source (and, for deploy, `--name`). The upgrade `app-id` is
+ * a positional arg, so its presence is checked at the call site; this helper
+ * only reports the image-source half for `"app-id"` callers.
+ *
+ * @param identityFlag "name" for deploy, "app-id" for upgrade.
+ */
+export function collectMissingRequiredInputs(
+  state: RequiredInputState,
+  identityFlag: "name" | "app-id",
+): string[] {
+  const missing: string[] = [];
+  const hasImageSource =
+    !!state.imageRef ||
+    !!state.dockerfile ||
+    (!!state.verifiable && !!state.repo && !!state.commit);
+  if (!hasImageSource) {
+    missing.push(
+      "an image source (one of: --image-ref, --dockerfile, or --verifiable with --repo and --commit)",
+    );
+  }
+  if (identityFlag === "name" && !state.name) {
+    missing.push("--name");
+  }
+  return missing;
 }
 
 // ==================== Dockerfile Selection ====================

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -123,6 +123,11 @@ export function collectMissingRequiredInputs(
     missing.push(
       "an image source (one of: --image-ref, --dockerfile, or --verifiable with --repo and --commit)",
     );
+  } else if (state.dockerfile && !state.imageRef && !state.verifiable) {
+    // A local --dockerfile build still needs a registry destination to push
+    // the built image to. Without --image-ref, the non-interactive run would
+    // otherwise fall through to an interactive --image-ref prompt and throw.
+    missing.push("--image-ref (registry destination for the built image)");
   }
   if (identityFlag === "name" && !state.name) {
     missing.push("--name");

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -135,7 +135,10 @@ export function collectMissingRequiredInputs(
 /**
  * Prompt for Dockerfile selection
  */
-export async function getDockerfileInteractive(dockerfilePath?: string): Promise<string> {
+export async function getDockerfileInteractive(
+  dockerfilePath?: string,
+  nonInteractive: boolean = false,
+): Promise<string> {
   // Check if provided via option
   if (dockerfilePath) {
     return dockerfilePath;
@@ -157,7 +160,7 @@ export async function getDockerfileInteractive(dockerfilePath?: string): Promise
   // sitting in the working directory. Callers that pass --image-ref skip this
   // helper entirely (see deploy.ts / upgrade.ts), so this default never
   // overrides an explicit image reference.
-  if (isNonInteractive()) {
+  if (nonInteractive) {
     warnDefaulted("--dockerfile/--image-ref", `build from '${dockerfilePath_resolved}'`);
     return dockerfilePath_resolved;
   }
@@ -890,7 +893,10 @@ export async function promptBuildIdFromRecentBuilds(options: {
 /**
  * Prompt for environment file
  */
-export async function getEnvFileInteractive(envFilePath?: string): Promise<string> {
+export async function getEnvFileInteractive(
+  envFilePath?: string,
+  nonInteractive: boolean = false,
+): Promise<string> {
   if (envFilePath && fs.existsSync(envFilePath)) {
     return envFilePath;
   }
@@ -901,7 +907,7 @@ export async function getEnvFileInteractive(envFilePath?: string): Promise<strin
 
   // In non-interactive mode, default to no env file (the same outcome as the
   // interactive "Continue without env file" choice).
-  if (isNonInteractive()) {
+  if (nonInteractive) {
     warnDefaulted("--env-file", "no env file");
     return "";
   }
@@ -1066,6 +1072,7 @@ export type LogVisibility = "public" | "private" | "off";
  */
 export async function getLogSettingsInteractive(
   logVisibility?: LogVisibility,
+  nonInteractive: boolean = false,
 ): Promise<{ logRedirect: string; publicLogs: boolean }> {
   if (logVisibility) {
     switch (logVisibility) {
@@ -1084,7 +1091,7 @@ export async function getLogSettingsInteractive(
 
   // In non-interactive mode, default to private logs. Never silently default
   // to public — private is the conservative choice for an unattended deploy.
-  if (isNonInteractive()) {
+  if (nonInteractive) {
     warnDefaulted("--log-visibility", "'private'");
     return { logRedirect: "always", publicLogs: false };
   }
@@ -1546,6 +1553,7 @@ export type ResourceUsageMonitoring = "enable" | "disable";
  */
 export async function getResourceUsageMonitoringInteractive(
   resourceUsageMonitoring?: ResourceUsageMonitoring,
+  nonInteractive: boolean = false,
 ): Promise<ResourceUsageMonitoring> {
   if (resourceUsageMonitoring) {
     switch (resourceUsageMonitoring) {
@@ -1560,7 +1568,7 @@ export async function getResourceUsageMonitoringInteractive(
   }
 
   // In non-interactive mode, default to disabled resource usage monitoring.
-  if (isNonInteractive()) {
+  if (nonInteractive) {
     warnDefaulted("--resource-usage-monitoring", "'disable'");
     return "disable";
   }

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -62,6 +62,28 @@ function ensureInteractive(missingFlagHint: string): void {
   }
 }
 
+/**
+ * True when there is no attached TTY (CI, scripted use, agents).
+ *
+ * The optional deploy/upgrade prompts (env file, log visibility, resource-usage
+ * monitoring, Dockerfile-vs-existing-image) all have a safe default, so rather
+ * than throwing via `ensureInteractive` they fall back to that default and log
+ * what was chosen. Required inputs with no safe default (image source,
+ * instance type, app name/id) keep calling `ensureInteractive` and still error.
+ */
+function isNonInteractive(): boolean {
+  return !process.stdin.isTTY;
+}
+
+/**
+ * Emit a single, consistent line noting that an optional flag was defaulted
+ * because we are running without a TTY. Keeps the choice visible/auditable in
+ * CI logs.
+ */
+function warnDefaulted(flagHint: string, chosen: string): void {
+  console.warn(`Warning: ${flagHint} not set in non-interactive mode; defaulting to ${chosen}.`);
+}
+
 // ==================== Dockerfile Selection ====================
 
 /**
@@ -81,6 +103,17 @@ export async function getDockerfileInteractive(dockerfilePath?: string): Promise
   if (!fs.existsSync(dockerfilePath_resolved)) {
     // No Dockerfile found, return empty string (deploy existing image)
     return "";
+  }
+
+  // In non-interactive mode we cannot ask the user to choose between building
+  // the discovered Dockerfile and deploying an existing image. Default to
+  // building from the discovered Dockerfile — the intent when a Dockerfile is
+  // sitting in the working directory. Callers that pass --image-ref skip this
+  // helper entirely (see deploy.ts / upgrade.ts), so this default never
+  // overrides an explicit image reference.
+  if (isNonInteractive()) {
+    warnDefaulted("--dockerfile/--image-ref", `build from '${dockerfilePath_resolved}'`);
+    return dockerfilePath_resolved;
   }
 
   // Interactive prompt when Dockerfile exists
@@ -820,6 +853,13 @@ export async function getEnvFileInteractive(envFilePath?: string): Promise<strin
     return ".env";
   }
 
+  // In non-interactive mode, default to no env file (the same outcome as the
+  // interactive "Continue without env file" choice).
+  if (isNonInteractive()) {
+    warnDefaulted("--env-file", "no env file");
+    return "";
+  }
+
   ensureInteractive("--env-file");
   console.log("\nEnvironment file not found.");
   console.log("Environment files contain variables like RPC_URL, etc.");
@@ -967,6 +1007,13 @@ export async function getLogSettingsInteractive(
           `Invalid log-visibility: ${logVisibility} (must be public, private, or off)`,
         );
     }
+  }
+
+  // In non-interactive mode, default to private logs. Never silently default
+  // to public — private is the conservative choice for an unattended deploy.
+  if (isNonInteractive()) {
+    warnDefaulted("--log-visibility", "'private'");
+    return { logRedirect: "always", publicLogs: false };
   }
 
   ensureInteractive("--log-visibility");
@@ -1437,6 +1484,12 @@ export async function getResourceUsageMonitoringInteractive(
           `Invalid resource-usage-monitoring: ${resourceUsageMonitoring} (must be enable or disable)`,
         );
     }
+  }
+
+  // In non-interactive mode, default to disabled resource usage monitoring.
+  if (isNonInteractive()) {
+    warnDefaulted("--resource-usage-monitoring", "'disable'");
+    return "disable";
   }
 
   ensureInteractive("--resource-usage-monitoring");

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -133,9 +133,10 @@ export function collectMissingRequiredInputs(
 // ==================== Dockerfile Selection ====================
 
 /**
- * Prompt for Dockerfile selection
+ * Resolve the Dockerfile path: explicit flag, else the discovered ./Dockerfile.
+ * When nonInteractive, defaults instead of prompting for build-vs-existing.
  */
-export async function getDockerfileInteractive(
+export async function getDockerfile(
   dockerfilePath?: string,
   nonInteractive: boolean = false,
 ): Promise<string> {
@@ -891,9 +892,10 @@ export async function promptBuildIdFromRecentBuilds(options: {
 // ==================== Environment File Selection ====================
 
 /**
- * Prompt for environment file
+ * Resolve the env file path: explicit flag, else auto-detected ./.env.
+ * When nonInteractive, defaults to no env file instead of prompting.
  */
-export async function getEnvFileInteractive(
+export async function getEnvFile(
   envFilePath?: string,
   nonInteractive: boolean = false,
 ): Promise<string> {
@@ -991,7 +993,7 @@ function formatSkuChoice(it: SkuInfo): string {
   return `${it.sku} - ${it.description}`;
 }
 
-export async function getInstanceTypeInteractive(
+export async function getInstanceType(
   instanceType: string | undefined,
   defaultSKU: string,
   availableTypes: SkuInfo[],
@@ -1068,9 +1070,10 @@ export async function getInstanceTypeInteractive(
 export type LogVisibility = "public" | "private" | "off";
 
 /**
- * Prompt for log settings
+ * Resolve log settings from the --log-visibility value.
+ * When nonInteractive, defaults to private instead of prompting.
  */
-export async function getLogSettingsInteractive(
+export async function getLogSettings(
   logVisibility?: LogVisibility,
   nonInteractive: boolean = false,
 ): Promise<{ logRedirect: string; publicLogs: boolean }> {
@@ -1549,9 +1552,10 @@ async function getAppIDInteractiveFromRegistry(
 export type ResourceUsageMonitoring = "enable" | "disable";
 
 /**
- * Prompt for resource usage monitoring settings
+ * Resolve the resource-usage-monitoring setting from the flag value.
+ * When nonInteractive, defaults to disable instead of prompting.
  */
-export async function getResourceUsageMonitoringInteractive(
+export async function getResourceUsageMonitoring(
   resourceUsageMonitoring?: ResourceUsageMonitoring,
   nonInteractive: boolean = false,
 ): Promise<ResourceUsageMonitoring> {

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -1595,9 +1595,7 @@ export async function confirmWithDefault(
   defaultValue: boolean = false,
 ): Promise<boolean> {
   if (!process.stdin.isTTY) {
-    throw new Error(
-      `Cannot confirm "${prompt}" in non-interactive mode. Use --force to skip confirmation prompts.`,
-    );
+    return defaultValue;
   }
   return await inquirerConfirm({
     message: prompt,

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -939,6 +939,13 @@ export async function getEnvFileInteractive(envFilePath?: string): Promise<strin
 // ==================== Instance Type Selection ====================
 
 /**
+ * Smallest TEE tier that runs a real workload (2 vCPU / 8 GB / AMD SEV-SNP);
+ * used as the non-interactive deploy default. Confirmed present in the live
+ * getSKUs list on mainnet-alpha and sepolia-prod (RND-589).
+ */
+export const DEFAULT_NONINTERACTIVE_SKU = "g1-standard-2s";
+
+/**
  * Prompt for instance type
  */
 export interface SkuInfo {
@@ -982,6 +989,7 @@ export async function getInstanceTypeInteractive(
   instanceType: string | undefined,
   defaultSKU: string,
   availableTypes: SkuInfo[],
+  nonInteractive: boolean = false,
 ): Promise<string> {
   if (instanceType) {
     // Validate provided instance type
@@ -991,6 +999,25 @@ export async function getInstanceTypeInteractive(
     }
     const validSKUs = availableTypes.map((t) => t.sku).join(", ");
     throw new Error(`Invalid instance-type: ${instanceType} (must be one of: ${validSKUs})`);
+  }
+
+  // Non-interactive: pick a default instead of prompting (RND-589).
+  // Callers pass isNonInteractive(flags) (flag + CI + isTTY) as this argument.
+  if (nonInteractive) {
+    // Upgrade path: reuse the currently pinned type when one is known.
+    if (defaultSKU) {
+      warnDefaulted("--instance-type", `current type '${defaultSKU}'`);
+      return defaultSKU;
+    }
+    // Deploy path: smallest TEE tier, if the backend offers it.
+    if (availableTypes.some((t) => t.sku === DEFAULT_NONINTERACTIVE_SKU)) {
+      warnDefaulted("--instance-type", `'${DEFAULT_NONINTERACTIVE_SKU}'`);
+      return DEFAULT_NONINTERACTIVE_SKU;
+    }
+    const validSKUs = availableTypes.map((t) => t.sku).join(", ");
+    throw new Error(
+      `Cannot pick a default --instance-type in non-interactive mode: '${DEFAULT_NONINTERACTIVE_SKU}' not offered (available: ${validSKUs}). Provide --instance-type.`,
+    );
   }
 
   ensureInteractive("--instance-type");

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -941,7 +941,7 @@ export async function getEnvFileInteractive(envFilePath?: string): Promise<strin
 /**
  * Smallest TEE tier that runs a real workload (2 vCPU / 8 GB / AMD SEV-SNP);
  * used as the non-interactive deploy default. Confirmed present in the live
- * getSKUs list on mainnet-alpha and sepolia-prod (RND-589).
+ * getSKUs list on mainnet-alpha and sepolia-prod.
  */
 export const DEFAULT_NONINTERACTIVE_SKU = "g1-standard-2s";
 
@@ -1001,7 +1001,7 @@ export async function getInstanceTypeInteractive(
     throw new Error(`Invalid instance-type: ${instanceType} (must be one of: ${validSKUs})`);
   }
 
-  // Non-interactive: pick a default instead of prompting (RND-589).
+  // Non-interactive: pick a default instead of prompting.
   // Callers pass isNonInteractive(flags) (flag + CI + isTTY) as this argument.
   if (nonInteractive) {
     // Upgrade path: reuse the currently pinned type when one is known.

--- a/packages/sdk/src/client/common/contract/watcher.ts
+++ b/packages/sdk/src/client/common/contract/watcher.ts
@@ -122,20 +122,83 @@ export interface WatchUntilUpgradeCompleteOptions {
   publicClient: PublicClient;
   environmentConfig: EnvironmentConfig;
   appId: Address;
+  /**
+   * Maximum time (in seconds) to wait for the upgrade to complete before
+   * throwing a {@link WatchTimeoutError}. If unspecified, defaults to
+   * the value of the `ECLOUD_WATCH_TIMEOUT_SECONDS` env var, falling back to
+   * {@link WATCH_DEFAULT_TIMEOUT_SECONDS}.
+   */
+  timeoutSeconds?: number;
 }
 
 const APP_STATUS_STOPPED = "Stopped";
 
+/** Default upgrade watch timeout: 10 minutes. */
+export const WATCH_DEFAULT_TIMEOUT_SECONDS = 10 * 60;
+
+/**
+ * Error thrown when {@link watchUntilUpgradeComplete} exceeds its deadline
+ * without observing a terminal status (Stopped or Running) for the app.
+ *
+ * Callers (e.g. the CLI) can catch this and surface a recovery hint pointing
+ * the user at `ecloud compute app info <appId>`.
+ */
+export class WatchTimeoutError extends Error {
+  public readonly appId: Address;
+  public readonly lastStatus: string | undefined;
+  public readonly elapsedSeconds: number;
+  public readonly timeoutSeconds: number;
+
+  constructor(params: {
+    appId: Address;
+    lastStatus: string | undefined;
+    elapsedSeconds: number;
+    timeoutSeconds: number;
+  }) {
+    super(
+      `Timed out after ${params.elapsedSeconds}s waiting for upgrade to complete (last status: ${
+        params.lastStatus ?? "unknown"
+      })`,
+    );
+    this.name = "WatchTimeoutError";
+    this.appId = params.appId;
+    this.lastStatus = params.lastStatus;
+    this.elapsedSeconds = params.elapsedSeconds;
+    this.timeoutSeconds = params.timeoutSeconds;
+  }
+}
+
+/**
+ * Resolve the upgrade watch timeout from explicit option, env var, or default.
+ */
+function resolveWatchTimeoutSeconds(explicit?: number): number {
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return explicit;
+  }
+  const fromEnv = process.env.ECLOUD_WATCH_TIMEOUT_SECONDS;
+  if (fromEnv) {
+    const parsed = Number.parseInt(fromEnv, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return WATCH_DEFAULT_TIMEOUT_SECONDS;
+}
+
 /**
  * Watch app until upgrade completes
  * For upgrades, we watch until the app reaches Stopped status (upgrade complete)
- * or Running status (if it was running before upgrade)
+ * or Running status (if it was running before upgrade).
+ *
+ * Throws {@link WatchTimeoutError} if the timeout elapses before a
+ * terminal status is observed.
  */
 export async function watchUntilUpgradeComplete(
   options: WatchUntilUpgradeCompleteOptions,
   logger: Logger,
 ): Promise<void> {
   const { walletClient, publicClient, environmentConfig, appId } = options;
+  const timeoutSeconds = resolveWatchTimeoutSeconds(options.timeoutSeconds);
 
   // Create UserAPI client
   const userApiClient = new UserApiClient(environmentConfig, walletClient, publicClient);
@@ -193,7 +256,21 @@ export async function watchUntilUpgradeComplete(
   };
 
   // Main watch loop
+  const startTime = Date.now();
+  const deadline = startTime + timeoutSeconds * 1000;
+  let lastLoggedStatus: string | undefined;
+  let lastObservedStatus: string | undefined;
   while (true) {
+    if (Date.now() >= deadline) {
+      const elapsedSeconds = Math.round((Date.now() - startTime) / 1000);
+      throw new WatchTimeoutError({
+        appId,
+        lastStatus: lastObservedStatus,
+        elapsedSeconds,
+        timeoutSeconds,
+      });
+    }
+
     try {
       // Fetch app info
       const info = await userApiClient.getInfos([appId], 1);
@@ -205,6 +282,14 @@ export async function watchUntilUpgradeComplete(
       const appInfo = info[0];
       const currentStatus = appInfo.status;
       const currentIP = appInfo.ip || "";
+      lastObservedStatus = currentStatus;
+
+      // Log status changes and elapsed time on a new line per transition
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      if (currentStatus !== lastLoggedStatus) {
+        logger.info(`Status: ${currentStatus} (${elapsed}s)`);
+        lastLoggedStatus = currentStatus;
+      }
 
       // Check stop condition
       if (stopCondition(currentStatus, currentIP)) {
@@ -214,6 +299,14 @@ export async function watchUntilUpgradeComplete(
       // Wait before next poll
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     } catch (error: any) {
+      // Re-throw timeout errors and terminal failures from stopCondition.
+      if (error instanceof WatchTimeoutError) {
+        throw error;
+      }
+      // Heuristic: stopCondition throws plain Error for "Failed" state — let it propagate.
+      if (typeof error?.message === "string" && error.message.includes("Failed")) {
+        throw error;
+      }
       logger.warn(`Failed to fetch app info: ${error.message}`);
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     }

--- a/packages/sdk/src/client/common/contract/watcher.ts
+++ b/packages/sdk/src/client/common/contract/watcher.ts
@@ -17,12 +17,69 @@ export interface WatchUntilRunningOptions {
   publicClient: PublicClient;
   environmentConfig: EnvironmentConfig;
   appId: Address;
+  /**
+   * Maximum seconds to wait before throwing {@link WatchTimeoutError}.
+   * Precedence: explicit value > `ECLOUD_WATCH_TIMEOUT_SECONDS` env var > 600s default.
+   */
+  timeoutSeconds?: number;
 }
 
 const WATCH_POLL_INTERVAL_SECONDS = 5;
+const WATCH_HEARTBEAT_INTERVAL_SECONDS = 30;
+export const WATCH_DEFAULT_TIMEOUT_SECONDS = 10 * 60;
 const APP_STATUS_RUNNING = "Running";
 const APP_STATUS_FAILED = "Failed";
 // const APP_STATUS_DEPLOYING = 'Deploying';
+
+/**
+ * Typed error thrown when watch loops exceed their timeout budget.
+ *
+ * Callers (e.g. the CLI) can catch this specifically to surface a
+ * troubleshooting hint without treating it as a generic failure.
+ */
+export class WatchTimeoutError extends Error {
+  public readonly appId: string;
+  public readonly elapsedSeconds: number;
+  public readonly lastStatus: string | undefined;
+  public readonly timeoutSeconds: number;
+
+  constructor(args: {
+    appId: string;
+    elapsedSeconds: number;
+    lastStatus: string | undefined;
+    timeoutSeconds: number;
+    message?: string;
+  }) {
+    super(
+      args.message ??
+        `Timed out after ${args.elapsedSeconds}s waiting for app ${args.appId} (last status: ${args.lastStatus ?? "unknown"})`,
+    );
+    this.name = "WatchTimeoutError";
+    this.appId = args.appId;
+    this.elapsedSeconds = args.elapsedSeconds;
+    this.lastStatus = args.lastStatus;
+    this.timeoutSeconds = args.timeoutSeconds;
+  }
+}
+
+/**
+ * Resolve the watch timeout in seconds, honoring the
+ * ECLOUD_WATCH_TIMEOUT_SECONDS environment override.
+ */
+function resolveWatchTimeoutSeconds(explicit?: number): number {
+  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
+    return Math.floor(explicit);
+  }
+  const raw = process.env.ECLOUD_WATCH_TIMEOUT_SECONDS;
+  if (raw === undefined || raw === "") {
+    return WATCH_DEFAULT_TIMEOUT_SECONDS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return WATCH_DEFAULT_TIMEOUT_SECONDS;
+  }
+  return Math.floor(parsed);
+}
 
 /**
  * Watch app until it reaches Running status with IP address
@@ -79,8 +136,23 @@ export async function watchUntilRunning(
 
   // Main watch loop
   const startTime = Date.now();
+  const timeoutSeconds = resolveWatchTimeoutSeconds(options.timeoutSeconds);
   let lastLoggedStatus: string | undefined;
+  let lastHeartbeatAt = startTime;
   while (true) {
+    const elapsedMs = Date.now() - startTime;
+    const elapsed = Math.round(elapsedMs / 1000);
+
+    // Bound the loop: surface a typed timeout so callers can hint the user.
+    if (elapsed >= timeoutSeconds) {
+      throw new WatchTimeoutError({
+        appId,
+        elapsedSeconds: elapsed,
+        lastStatus: lastLoggedStatus,
+        timeoutSeconds,
+      });
+    }
+
     try {
       // Fetch app info
       const info = await userApiClient.getInfos([appId], 1);
@@ -93,11 +165,16 @@ export async function watchUntilRunning(
       const currentStatus = appInfo.status;
       const currentIP = appInfo.ip || "";
 
-      // Log status changes and elapsed time
-      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      // Log status transitions, plus a periodic heartbeat so non-TTY
+      // stdout (where carriage-return updates are invisible) still shows
+      // progress when the status string is unchanged for a long time.
       if (currentStatus !== lastLoggedStatus) {
         logger.info(`Status: ${currentStatus} (${elapsed}s)`);
         lastLoggedStatus = currentStatus;
+        lastHeartbeatAt = Date.now();
+      } else if (Date.now() - lastHeartbeatAt >= WATCH_HEARTBEAT_INTERVAL_SECONDS * 1000) {
+        logger.info(`Status: ${currentStatus} (${elapsed}s)`);
+        lastHeartbeatAt = Date.now();
       }
 
       // Check stop condition
@@ -108,6 +185,10 @@ export async function watchUntilRunning(
       // Wait before next poll
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     } catch (error: any) {
+      // Re-throw typed terminal errors so the caller can react to them.
+      if (error instanceof WatchTimeoutError) {
+        throw error;
+      }
       logger.warn(`Failed to fetch app info: ${error.message}`);
       await sleep(WATCH_POLL_INTERVAL_SECONDS * 1000);
     }

--- a/packages/sdk/src/client/common/contract/watcher.ts
+++ b/packages/sdk/src/client/common/contract/watcher.ts
@@ -214,57 +214,8 @@ export interface WatchUntilUpgradeCompleteOptions {
 
 const APP_STATUS_STOPPED = "Stopped";
 
-/** Default upgrade watch timeout: 10 minutes. */
-export const WATCH_DEFAULT_TIMEOUT_SECONDS = 10 * 60;
-
-/**
- * Error thrown when {@link watchUntilUpgradeComplete} exceeds its deadline
- * without observing a terminal status (Stopped or Running) for the app.
- *
- * Callers (e.g. the CLI) can catch this and surface a recovery hint pointing
- * the user at `ecloud compute app info <appId>`.
- */
-export class WatchTimeoutError extends Error {
-  public readonly appId: Address;
-  public readonly lastStatus: string | undefined;
-  public readonly elapsedSeconds: number;
-  public readonly timeoutSeconds: number;
-
-  constructor(params: {
-    appId: Address;
-    lastStatus: string | undefined;
-    elapsedSeconds: number;
-    timeoutSeconds: number;
-  }) {
-    super(
-      `Timed out after ${params.elapsedSeconds}s waiting for upgrade to complete (last status: ${
-        params.lastStatus ?? "unknown"
-      })`,
-    );
-    this.name = "WatchTimeoutError";
-    this.appId = params.appId;
-    this.lastStatus = params.lastStatus;
-    this.elapsedSeconds = params.elapsedSeconds;
-    this.timeoutSeconds = params.timeoutSeconds;
-  }
-}
-
-/**
- * Resolve the upgrade watch timeout from explicit option, env var, or default.
- */
-function resolveWatchTimeoutSeconds(explicit?: number): number {
-  if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) {
-    return explicit;
-  }
-  const fromEnv = process.env.ECLOUD_WATCH_TIMEOUT_SECONDS;
-  if (fromEnv) {
-    const parsed = Number.parseInt(fromEnv, 10);
-    if (Number.isFinite(parsed) && parsed > 0) {
-      return parsed;
-    }
-  }
-  return WATCH_DEFAULT_TIMEOUT_SECONDS;
-}
+// WATCH_DEFAULT_TIMEOUT_SECONDS, WatchTimeoutError, and resolveWatchTimeoutSeconds
+// are shared with watchUntilRunning and declared once near the top of this file.
 
 /**
  * Watch app until upgrade completes

--- a/packages/sdk/src/client/common/gas/__tests__/insufficientGas.test.ts
+++ b/packages/sdk/src/client/common/gas/__tests__/insufficientGas.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { Address, PublicClient } from "viem";
+import { assertSufficientGas, InsufficientGasError } from "../insufficientGas";
+import type { GasEstimate } from "../../contract/caller";
+
+const ADDR = "0x540d6701c396f77c3601FC34585107497ED71495" as Address;
+
+function gasEstimate(maxCostWei: bigint): GasEstimate {
+  return {
+    gasLimit: BigInt(21000),
+    maxFeePerGas: BigInt(1),
+    maxPriorityFeePerGas: BigInt(1),
+    maxCostWei,
+    maxCostEth: "0",
+  };
+}
+
+function clientWithBalance(balanceWei: bigint): PublicClient {
+  return { getBalance: async () => balanceWei } as unknown as PublicClient;
+}
+
+describe("assertSufficientGas (RND-596)", () => {
+  it("passes when balance exceeds the estimate", async () => {
+    await expect(
+      assertSufficientGas({
+        publicClient: clientWithBalance(BigInt(10)),
+        address: ADDR,
+        gasEstimate: gasEstimate(BigInt(5)),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes when balance exactly equals the estimate", async () => {
+    await expect(
+      assertSufficientGas({
+        publicClient: clientWithBalance(BigInt(5)),
+        address: ADDR,
+        gasEstimate: gasEstimate(BigInt(5)),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws InsufficientGasError on dust below the estimate (not just zero)", async () => {
+    await expect(
+      assertSufficientGas({
+        publicClient: clientWithBalance(BigInt(4)),
+        address: ADDR,
+        gasEstimate: gasEstimate(BigInt(5)),
+      }),
+    ).rejects.toBeInstanceOf(InsufficientGasError);
+  });
+
+  it("error carries required/available and a credits-don't-pay-gas message", async () => {
+    try {
+      await assertSufficientGas({
+        publicClient: clientWithBalance(BigInt(0)),
+        address: ADDR,
+        gasEstimate: gasEstimate(BigInt(7)),
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InsufficientGasError);
+      const e = err as InsufficientGasError;
+      expect(e.requiredWei).toBe(BigInt(7));
+      expect(e.availableWei).toBe(BigInt(0));
+      expect(e.address).toBe(ADDR);
+      expect(e.message).toMatch(/credits do not pay on-chain gas/i);
+    }
+  });
+});

--- a/packages/sdk/src/client/common/gas/__tests__/insufficientGas.test.ts
+++ b/packages/sdk/src/client/common/gas/__tests__/insufficientGas.test.ts
@@ -19,7 +19,7 @@ function clientWithBalance(balanceWei: bigint): PublicClient {
   return { getBalance: async () => balanceWei } as unknown as PublicClient;
 }
 
-describe("assertSufficientGas (RND-596)", () => {
+describe("assertSufficientGas", () => {
   it("passes when balance exceeds the estimate", async () => {
     await expect(
       assertSufficientGas({

--- a/packages/sdk/src/client/common/gas/insufficientGas.ts
+++ b/packages/sdk/src/client/common/gas/insufficientGas.ts
@@ -1,0 +1,56 @@
+import type { Address, PublicClient } from "viem";
+import { formatEther } from "viem";
+import type { GasEstimate } from "../contract/caller";
+
+/**
+ * Thrown when the wallet's native ETH balance is below the estimated on-chain
+ * gas cost for a deploy/upgrade.
+ *
+ * Compute credits (Stripe / USDC-converted) do NOT pay on-chain gas — gas is
+ * paid by the user's EOA at send time via EIP-7702. Without this pre-flight the
+ * transaction reverts only after submission, which to an agent is
+ * indistinguishable from other failures (RND-596).
+ */
+export class InsufficientGasError extends Error {
+  public readonly address: Address;
+  public readonly requiredWei: bigint;
+  public readonly availableWei: bigint;
+  public readonly requiredEth: string;
+  public readonly availableEth: string;
+
+  constructor(args: { address: Address; requiredWei: bigint; availableWei: bigint }) {
+    const requiredEth = formatEther(args.requiredWei);
+    const availableEth = formatEther(args.availableWei);
+    super(
+      `Insufficient ETH for gas: wallet ${args.address} has ${availableEth} ETH but ` +
+        `this transaction needs ~${requiredEth} ETH.\n` +
+        `Compute credits do not pay on-chain gas — fund the wallet with ETH and retry.`,
+    );
+    this.name = "InsufficientGasError";
+    this.address = args.address;
+    this.requiredWei = args.requiredWei;
+    this.availableWei = args.availableWei;
+    this.requiredEth = requiredEth;
+    this.availableEth = availableEth;
+  }
+}
+
+/**
+ * Pre-flight gate: throw {@link InsufficientGasError} when the wallet's ETH
+ * balance is below the estimated gas cost. The threshold is the gas estimate
+ * (`maxCostWei`), not zero — dust below the cost must still fail.
+ */
+export async function assertSufficientGas(args: {
+  publicClient: PublicClient;
+  address: Address;
+  gasEstimate: GasEstimate;
+}): Promise<void> {
+  const availableWei = await args.publicClient.getBalance({ address: args.address });
+  if (availableWei < args.gasEstimate.maxCostWei) {
+    throw new InsufficientGasError({
+      address: args.address,
+      requiredWei: args.gasEstimate.maxCostWei,
+      availableWei,
+    });
+  }
+}

--- a/packages/sdk/src/client/common/gas/insufficientGas.ts
+++ b/packages/sdk/src/client/common/gas/insufficientGas.ts
@@ -9,7 +9,7 @@ import type { GasEstimate } from "../contract/caller";
  * Compute credits (Stripe / USDC-converted) do NOT pay on-chain gas — gas is
  * paid by the user's EOA at send time via EIP-7702. Without this pre-flight the
  * transaction reverts only after submission, which to an agent is
- * indistinguishable from other failures (RND-596).
+ * indistinguishable from other failures.
  */
 export class InsufficientGasError extends Error {
   public readonly address: Address;

--- a/packages/sdk/src/client/common/registry/__tests__/digest.test.ts
+++ b/packages/sdk/src/client/common/registry/__tests__/digest.test.ts
@@ -56,4 +56,20 @@ describe("getImageDigestAndName amd64 enforcement", () => {
     });
     await expect(getImageDigestAndName("docker.io/x/y:tag")).rejects.toThrow(/linux\/amd64/);
   });
+
+  it("remediation offers buildx and the --verifiable --repo --commit server-side path", async () => {
+    // The remediation must point at both fixes a non-amd64 --image-ref has:
+    // rebuild for amd64 with buildx, OR switch to a server-side verifiable build
+    // (which needs no local Docker at all). Kept consistent with the CLI's
+    // prebuilt-image rejection so both arm64 entry points say the same thing.
+    responses.manifest = JSON.stringify({
+      manifests: [
+        { digest: "sha256:" + "d".repeat(64), platform: { os: "linux", architecture: "arm64" } },
+      ],
+    });
+    await expect(getImageDigestAndName("docker.io/x/y:tag")).rejects.toThrow(/buildx/);
+    await expect(getImageDigestAndName("docker.io/x/y:tag")).rejects.toThrow(
+      /--verifiable --repo .* --commit/,
+    );
+  });
 });

--- a/packages/sdk/src/client/common/registry/__tests__/digest.test.ts
+++ b/packages/sdk/src/client/common/registry/__tests__/digest.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock child_process.execFile so promisify(execFile) is drivable. The real
+// signature is execFile(cmd, args, opts, cb); promisify calls the (err, {stdout})
+// node-style callback. We route by the docker subcommand.
+const responses: Record<string, string> = {};
+vi.mock("child_process", () => ({
+  execFile: (
+    _cmd: string,
+    args: string[],
+    _opts: unknown,
+    cb: (err: Error | null, res?: { stdout: string; stderr: string }) => void,
+  ) => {
+    const sub = args[0]; // "manifest" | "inspect"
+    const key = sub === "manifest" ? "manifest" : "inspect";
+    const out = responses[key];
+    if (out === undefined) {
+      cb(new Error(`no mock for docker ${args.join(" ")}`));
+      return;
+    }
+    cb(null, { stdout: out, stderr: "" });
+  },
+}));
+
+import { getImageDigestAndName } from "../digest";
+
+describe("getImageDigestAndName amd64 enforcement (RND-597)", () => {
+  afterEach(() => {
+    for (const k of Object.keys(responses)) delete responses[k];
+    vi.clearAllMocks();
+  });
+
+  it("throws (fail closed) when architecture is undetectable — no assume-amd64", async () => {
+    // Single-platform manifest (no .manifests[]), so it calls `docker inspect`,
+    // whose output has NO Architecture field but the manifest has a config digest.
+    responses.manifest = JSON.stringify({ config: { digest: "sha256:" + "b".repeat(64) } });
+    responses.inspect = JSON.stringify([{ Os: "linux" /* Architecture missing */ }]);
+
+    await expect(getImageDigestAndName("docker.io/x/y:tag")).rejects.toThrow(/linux\/amd64/);
+  });
+
+  it("rejects a single-platform arm64 image", async () => {
+    responses.manifest = JSON.stringify({ config: { digest: "sha256:" + "b".repeat(64) } });
+    responses.inspect = JSON.stringify([
+      { Os: "linux", Architecture: "arm64", RepoDigests: ["x@sha256:" + "c".repeat(64)] },
+    ]);
+
+    await expect(getImageDigestAndName("docker.io/x/y:tag")).rejects.toThrow(/linux\/amd64/);
+  });
+
+  it("rejects a multi-platform image with no linux/amd64 entry", async () => {
+    responses.manifest = JSON.stringify({
+      manifests: [
+        { digest: "sha256:" + "d".repeat(64), platform: { os: "linux", architecture: "arm64" } },
+      ],
+    });
+    await expect(getImageDigestAndName("docker.io/x/y:tag")).rejects.toThrow(/linux\/amd64/);
+  });
+});

--- a/packages/sdk/src/client/common/registry/__tests__/digest.test.ts
+++ b/packages/sdk/src/client/common/registry/__tests__/digest.test.ts
@@ -24,7 +24,7 @@ vi.mock("child_process", () => ({
 
 import { getImageDigestAndName } from "../digest";
 
-describe("getImageDigestAndName amd64 enforcement (RND-597)", () => {
+describe("getImageDigestAndName amd64 enforcement", () => {
   afterEach(() => {
     for (const k of Object.keys(responses)) delete responses[k];
     vi.clearAllMocks();

--- a/packages/sdk/src/client/common/registry/digest.ts
+++ b/packages/sdk/src/client/common/registry/digest.ts
@@ -116,18 +116,11 @@ async function extractDigestFromSinglePlatform(
       : null;
 
     if (!config) {
-      // Try to get from manifest config digest
-      if (manifest.config?.digest) {
-        const digest = hexStringToBytes32(manifest.config.digest);
-        const registry = extractRegistryName(imageRef);
-        // Assume linux/amd64 if we can't determine platform
-        return {
-          digest,
-          registry,
-          platform: DOCKER_PLATFORM,
-        };
-      }
-      throw new Error(`Could not determine platform for ${imageRef}`);
+      // Architecture is undetectable from `docker inspect`. Previously this
+      // assumed linux/amd64 and deployed anyway — the silent hole that let an
+      // arm64 image through to crash on first request in the TEE. Fail closed
+      // instead: refuse rather than guess the platform (RND-597).
+      throw createPlatformErrorMessage(imageRef, ["unknown (could not determine architecture)"]);
     }
 
     const platform = `${config.os}/${config.architecture}`;

--- a/packages/sdk/src/client/common/registry/digest.ts
+++ b/packages/sdk/src/client/common/registry/digest.ts
@@ -119,7 +119,7 @@ async function extractDigestFromSinglePlatform(
       // Architecture is undetectable from `docker inspect`. Previously this
       // assumed linux/amd64 and deployed anyway — the silent hole that let an
       // arm64 image through to crash on first request in the TEE. Fail closed
-      // instead: refuse rather than guess the platform (RND-597).
+      // instead: refuse rather than guess the platform.
       throw createPlatformErrorMessage(imageRef, ["unknown (could not determine architecture)"]);
     }
 

--- a/packages/sdk/src/client/common/registry/digest.ts
+++ b/packages/sdk/src/client/common/registry/digest.ts
@@ -229,14 +229,11 @@ Image: ${imageRef}
 Found platform(s): ${platforms.join(", ")}
 Required platform: ${DOCKER_PLATFORM}
 
-To fix this issue:
-1. Manual fix:
-   a. Rebuild your image with the correct platform:
-      docker build --platform ${DOCKER_PLATFORM} -t ${imageRef} .
-   b. Push the rebuilt image to your remote registry:
-      docker push ${imageRef}
-
-2. Or use the SDK to build with the correct platform automatically.`;
+To fix, either:
+1. Rebuild the image for ${DOCKER_PLATFORM} and push it:
+     docker buildx build --platform ${DOCKER_PLATFORM} -t ${imageRef} --push .
+2. Or use a verifiable build (--verifiable --repo <repo> --commit <sha>), which
+   builds server-side and needs no local Docker.`;
 
   return new Error(errorMsg);
 }

--- a/packages/sdk/src/client/common/release/prepare.ts
+++ b/packages/sdk/src/client/common/release/prepare.ts
@@ -72,7 +72,7 @@ export async function prepareRelease(
     await new Promise((resolve) => setTimeout(resolve, REGISTRY_PROPAGATION_WAIT_SECONDS * 1000));
   } else {
     // Pre-flight: verify the remote image is linux/amd64 BEFORE the slow
-    // pull+layer+push (RND-597). getImageDigestAndName runs `docker manifest
+    // pull+layer+push. getImageDigestAndName runs `docker manifest
     // inspect` (no pull) and throws the platform-remediation error for a
     // non-amd64 image, so an arm64 --image-ref fails in seconds instead of
     // minutes — and never slips through to crash in the TEE.

--- a/packages/sdk/src/client/common/release/prepare.ts
+++ b/packages/sdk/src/client/common/release/prepare.ts
@@ -71,6 +71,14 @@ export async function prepareRelease(
     logger.info(`Waiting ${REGISTRY_PROPAGATION_WAIT_SECONDS} seconds for registry propagation...`);
     await new Promise((resolve) => setTimeout(resolve, REGISTRY_PROPAGATION_WAIT_SECONDS * 1000));
   } else {
+    // Pre-flight: verify the remote image is linux/amd64 BEFORE the slow
+    // pull+layer+push (RND-597). getImageDigestAndName runs `docker manifest
+    // inspect` (no pull) and throws the platform-remediation error for a
+    // non-amd64 image, so an arm64 --image-ref fails in seconds instead of
+    // minutes — and never slips through to crash in the TEE.
+    logger.info("Verifying image platform (linux/amd64)...");
+    await getImageDigestAndName(imageRef);
+
     // Layer remote image if needed
     logger.info("Checking if image needs layering...");
     finalImageRef = await layerRemoteImageIfNeeded(

--- a/packages/sdk/src/client/common/utils/__tests__/retry.test.ts
+++ b/packages/sdk/src/client/common/utils/__tests__/retry.test.ts
@@ -9,11 +9,11 @@ vi.mock("axios", () => ({
 import { requestWithRetry } from "../retry";
 
 /**
- * RND-592: requestWithRetry retries 429 (rate limit) AND transient gateway
+ * requestWithRetry retries 429 (rate limit) AND transient gateway
  * errors 502/503/504, then returns the last response. 2xx/4xx (other than 429)
  * are returned immediately without retry.
  */
-describe("requestWithRetry retryable statuses (RND-592)", () => {
+describe("requestWithRetry retryable statuses", () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();

--- a/packages/sdk/src/client/common/utils/__tests__/retry.test.ts
+++ b/packages/sdk/src/client/common/utils/__tests__/retry.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock axios so requestWithRetry's HTTP calls are controllable.
+const axiosMock = vi.fn();
+vi.mock("axios", () => ({
+  default: (config: unknown) => axiosMock(config),
+}));
+
+import { requestWithRetry } from "../retry";
+
+/**
+ * RND-592: requestWithRetry retries 429 (rate limit) AND transient gateway
+ * errors 502/503/504, then returns the last response. 2xx/4xx (other than 429)
+ * are returned immediately without retry.
+ */
+describe("requestWithRetry retryable statuses (RND-592)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns immediately on 200 (no retry)", async () => {
+    axiosMock.mockResolvedValueOnce({ status: 200, headers: {}, data: "ok" });
+    const res = await requestWithRetry({ url: "x" });
+    expect(res.status).toBe(200);
+    expect(axiosMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 404", async () => {
+    axiosMock.mockResolvedValueOnce({ status: 404, headers: {}, data: "nope" });
+    const res = await requestWithRetry({ url: "x" });
+    expect(res.status).toBe(404);
+    expect(axiosMock).toHaveBeenCalledTimes(1);
+  });
+
+  for (const status of [429, 502, 503, 504]) {
+    it(`retries ${status} then succeeds`, async () => {
+      vi.useFakeTimers();
+      axiosMock
+        .mockResolvedValueOnce({ status, headers: { "retry-after": "0" }, data: "" })
+        .mockResolvedValueOnce({ status: 200, headers: {}, data: "ok" });
+
+      const promise = requestWithRetry({ url: "x" });
+      await vi.runAllTimersAsync();
+      const res = await promise;
+
+      expect(res.status).toBe(200);
+      expect(axiosMock).toHaveBeenCalledTimes(2);
+    });
+  }
+});

--- a/packages/sdk/src/client/common/utils/retry.ts
+++ b/packages/sdk/src/client/common/utils/retry.ts
@@ -7,7 +7,7 @@ const MAX_BACKOFF_MS = 30000;
 /**
  * HTTP statuses worth retrying with backoff: rate limiting (429) and transient
  * gateway/availability errors (502/503/504). Agents that poll status hit these
- * under load, and they are routinely recoverable on retry (RND-592).
+ * under load, and they are routinely recoverable on retry.
  */
 const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
 

--- a/packages/sdk/src/client/common/utils/retry.ts
+++ b/packages/sdk/src/client/common/utils/retry.ts
@@ -4,6 +4,13 @@ const MAX_RETRIES = 5;
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 30000;
 
+/**
+ * HTTP statuses worth retrying with backoff: rate limiting (429) and transient
+ * gateway/availability errors (502/503/504). Agents that poll status hit these
+ * under load, and they are routinely recoverable on retry (RND-592).
+ */
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -27,7 +34,7 @@ export async function requestWithRetry(config: AxiosRequestConfig): Promise<Axio
     const res = await axios({ ...config, validateStatus: () => true });
     lastResponse = res;
 
-    if (res.status !== 429) {
+    if (!RETRYABLE_STATUSES.has(res.status)) {
       return res;
     }
 

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -51,6 +51,7 @@ export {
   type WatchUpgradeOptions,
 } from "./modules/compute/app/upgrade";
 export { WatchTimeoutError, WATCH_DEFAULT_TIMEOUT_SECONDS } from "./common/contract/watcher";
+export { InsufficientGasError, assertSufficientGas } from "./common/gas/insufficientGas";
 
 // Export compute module for standalone use
 export {

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -47,7 +47,9 @@ export {
   executeUpgrade,
   watchUpgrade,
   type PrepareUpgradeResult,
+  type WatchUpgradeOptions,
 } from "./modules/compute/app/upgrade";
+export { WatchTimeoutError, WATCH_DEFAULT_TIMEOUT_SECONDS } from "./common/contract/watcher";
 
 // Export compute module for standalone use
 export {

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -39,6 +39,7 @@ export {
   executeDeploy,
   watchDeployment,
   type PrepareDeployResult,
+  type WatchDeploymentOptions,
 } from "./modules/compute/app/deploy";
 export {
   SDKUpgradeOptions,
@@ -111,6 +112,9 @@ export {
   type GasEstimate,
   type EstimateGasOptions,
 } from "./common/contract/caller";
+
+// Export watcher errors so callers can react to typed terminal failures.
+export { WatchTimeoutError } from "./common/contract/watcher";
 
 // Export batch gas estimation and delegation check
 export {

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -115,9 +115,6 @@ export {
   type EstimateGasOptions,
 } from "./common/contract/caller";
 
-// Export watcher errors so callers can react to typed terminal failures.
-export { WatchTimeoutError } from "./common/contract/watcher";
-
 // Export batch gas estimation and delegation check
 export {
   estimateBatchGas,

--- a/packages/sdk/src/client/modules/compute/app/deploy.ts
+++ b/packages/sdk/src/client/modules/compute/app/deploy.ts
@@ -711,6 +711,10 @@ export async function executeDeploy(options: ExecuteDeployOptions): Promise<Depl
  * Call this after executeDeploy to wait for the app to be provisioned.
  * Can be called separately to allow for intermediate operations (e.g., profile upload).
  */
+export interface WatchDeploymentOptions {
+  timeoutSeconds?: number;
+}
+
 export async function watchDeployment(
   appId: string,
   walletClient: WalletClient,
@@ -718,6 +722,7 @@ export async function watchDeployment(
   environmentConfig: EnvironmentConfig,
   logger: Logger = defaultLogger,
   skipTelemetry?: boolean,
+  opts?: WatchDeploymentOptions,
 ): Promise<string | undefined> {
   return withSDKTelemetry(
     {
@@ -735,6 +740,7 @@ export async function watchDeployment(
           publicClient,
           environmentConfig,
           appId: appId as Address,
+          timeoutSeconds: opts?.timeoutSeconds,
         },
         logger,
       );

--- a/packages/sdk/src/client/modules/compute/app/deploy.ts
+++ b/packages/sdk/src/client/modules/compute/app/deploy.ts
@@ -29,6 +29,7 @@ import {
 } from "../../../common/contract/caller";
 import { estimateBatchGas, createAuthorizationList } from "../../../common/contract/eip7702";
 import { type GasEstimate } from "../../../common/contract/caller";
+import { assertSufficientGas } from "../../../common/gas/insufficientGas";
 import { watchUntilRunning } from "../../../common/contract/watcher";
 import {
   validateAppName,
@@ -269,6 +270,13 @@ export async function prepareDeployFromVerifiableBuild(
         account: batch.walletClient.account!.address,
         executions: batch.executions,
         authorizationList,
+      });
+
+      // Pre-flight: block if the wallet can't cover gas (credits don't pay it).
+      await assertSufficientGas({
+        publicClient: batch.publicClient,
+        address: batch.walletClient.account!.address,
+        gasEstimate,
       });
 
       // Extract only data fields for public type (clients stay internal)
@@ -653,6 +661,13 @@ export async function prepareDeploy(
         account: batch.walletClient.account!.address,
         executions: batch.executions,
         authorizationList,
+      });
+
+      // 10b. Pre-flight: block if the wallet can't cover gas (credits don't pay it).
+      await assertSufficientGas({
+        publicClient: batch.publicClient,
+        address: batch.walletClient.account!.address,
+        gasEstimate,
       });
 
       // Extract only data fields for public type (clients stay internal)

--- a/packages/sdk/src/client/modules/compute/app/index.ts
+++ b/packages/sdk/src/client/modules/compute/app/index.ts
@@ -23,6 +23,7 @@ import {
   prepareUpgradeFromVerifiableBuild as prepareUpgradeFromVerifiableBuildFn,
   executeUpgrade as executeUpgradeFn,
   watchUpgrade as watchUpgradeFn,
+  type WatchUpgradeOptions,
 } from "./upgrade";
 import { createApp, CreateAppOpts } from "./create";
 import { logs, LogsOptions } from "./logs";
@@ -143,7 +144,7 @@ export interface AppModule {
     gasEstimate: GasEstimate;
   }>;
   executeUpgrade: (prepared: PreparedUpgrade, gas?: GasEstimate) => Promise<ExecuteUpgradeResult>;
-  watchUpgrade: (appId: AppId) => Promise<void>;
+  watchUpgrade: (appId: AppId, opts?: WatchUpgradeOptions) => Promise<void>;
 
   // Profile management
   setProfile: (appId: AppId, profile: AppProfile) => Promise<AppProfileResponse>;
@@ -383,8 +384,16 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
       };
     },
 
-    async watchUpgrade(appId) {
-      return watchUpgradeFn(appId, walletClient, publicClient, environment, logger, skipTelemetry);
+    async watchUpgrade(appId, opts) {
+      return watchUpgradeFn(
+        appId,
+        walletClient,
+        publicClient,
+        environment,
+        logger,
+        skipTelemetry,
+        opts,
+      );
     },
 
     // Profile management

--- a/packages/sdk/src/client/modules/compute/app/index.ts
+++ b/packages/sdk/src/client/modules/compute/app/index.ts
@@ -57,6 +57,7 @@ import type {
   PrepareUpgradeFromVerifiableBuildOpts,
   PreparedDeploy,
   PreparedUpgrade,
+  Logger,
 } from "../../../common/types";
 import { getLogger } from "../../../common/utils";
 
@@ -181,6 +182,12 @@ export interface AppModuleConfig {
   environment: string;
   clientId?: string;
   skipTelemetry?: boolean; // Skip telemetry when called from CLI
+  /**
+   * Optional logger override. Defaults to a stdout/stderr logger that respects
+   * `verbose`. Callers producing machine-readable output pass a logger that
+   * keeps progress off stdout.
+   */
+  logger?: Logger;
 }
 
 export function createAppModule(ctx: AppModuleConfig): AppModule {
@@ -196,8 +203,8 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
   // Pull config for selected Environment
   const environment = getEnvironmentConfig(ctx.environment);
 
-  // Get logger that respects verbose setting
-  const logger = getLogger(ctx.verbose);
+  // Use the caller-provided logger if any, else one that respects verbose.
+  const logger = ctx.logger ?? getLogger(ctx.verbose);
 
   return {
     async create(opts) {

--- a/packages/sdk/src/client/modules/compute/app/index.ts
+++ b/packages/sdk/src/client/modules/compute/app/index.ts
@@ -16,6 +16,7 @@ import {
   prepareDeployFromVerifiableBuild as prepareDeployFromVerifiableBuildFn,
   executeDeploy as executeDeployFn,
   watchDeployment as watchDeploymentFn,
+  type WatchDeploymentOptions,
 } from "./deploy";
 import {
   upgrade as upgradeApp,
@@ -125,7 +126,10 @@ export interface AppModule {
     gasEstimate: GasEstimate;
   }>;
   executeDeploy: (prepared: PreparedDeploy, gas?: GasEstimate) => Promise<ExecuteDeployResult>;
-  watchDeployment: (appId: AppId) => Promise<string | undefined>;
+  watchDeployment: (
+    appId: AppId,
+    opts?: WatchDeploymentOptions,
+  ) => Promise<string | undefined>;
 
   // Granular upgrade control
   prepareUpgrade: (
@@ -314,7 +318,7 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
       };
     },
 
-    async watchDeployment(appId) {
+    async watchDeployment(appId, opts) {
       return watchDeploymentFn(
         appId,
         walletClient,
@@ -322,6 +326,7 @@ export function createAppModule(ctx: AppModuleConfig): AppModule {
         environment,
         logger,
         skipTelemetry,
+        opts,
       );
     },
 

--- a/packages/sdk/src/client/modules/compute/app/upgrade.ts
+++ b/packages/sdk/src/client/modules/compute/app/upgrade.ts
@@ -27,6 +27,7 @@ import {
   type GasEstimate,
 } from "../../../common/contract/caller";
 import { estimateBatchGas, createAuthorizationList } from "../../../common/contract/eip7702";
+import { assertSufficientGas } from "../../../common/gas/insufficientGas";
 import { watchUntilUpgradeComplete } from "../../../common/contract/watcher";
 import {
   validateAppID,
@@ -199,6 +200,13 @@ export async function prepareUpgradeFromVerifiableBuild(
         account: batch.walletClient.account!.address,
         executions: batch.executions,
         authorizationList,
+      });
+
+      // Pre-flight: block if the wallet can't cover gas (credits don't pay it).
+      await assertSufficientGas({
+        publicClient: batch.publicClient,
+        address: batch.walletClient.account!.address,
+        gasEstimate,
       });
 
       // Extract only data fields for public type (clients stay internal)
@@ -487,6 +495,13 @@ export async function prepareUpgrade(
         account: batch.walletClient.account!.address,
         executions: batch.executions,
         authorizationList,
+      });
+
+      // Pre-flight: block if the wallet can't cover gas (credits don't pay it).
+      await assertSufficientGas({
+        publicClient: batch.publicClient,
+        address: batch.walletClient.account!.address,
+        gasEstimate,
       });
 
       // Extract only data fields for public type (clients stay internal)

--- a/packages/sdk/src/client/modules/compute/app/upgrade.ts
+++ b/packages/sdk/src/client/modules/compute/app/upgrade.ts
@@ -543,6 +543,10 @@ export async function executeUpgrade(options: ExecuteUpgradeOptions): Promise<Up
  * Call this after executeUpgrade to wait for the upgrade to finish.
  * Can be called separately to allow for intermediate operations.
  */
+export interface WatchUpgradeOptions {
+  timeoutSeconds?: number;
+}
+
 export async function watchUpgrade(
   appId: string,
   walletClient: WalletClient,
@@ -550,6 +554,7 @@ export async function watchUpgrade(
   environmentConfig: EnvironmentConfig,
   logger: Logger = defaultLogger,
   skipTelemetry?: boolean,
+  opts?: WatchUpgradeOptions,
 ): Promise<void> {
   return withSDKTelemetry(
     {
@@ -567,6 +572,7 @@ export async function watchUpgrade(
           publicClient,
           environmentConfig,
           appId: appId as Address,
+          timeoutSeconds: opts?.timeoutSeconds,
         },
         logger,
       );

--- a/packages/sdk/src/client/modules/compute/index.ts
+++ b/packages/sdk/src/client/modules/compute/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { type WalletClient, type PublicClient } from "viem";
+import { type Logger } from "../../common/types";
 import { createAppModule, type AppModule } from "./app";
 
 export interface ComputeModule {
@@ -16,6 +17,13 @@ export interface ComputeModuleConfig {
   environment: string;
   clientId?: string;
   skipTelemetry?: boolean;
+  /**
+   * Optional logger override. When provided, the module routes all progress
+   * output through it instead of the default stdout/stderr logger. Callers
+   * emitting machine-readable output (e.g. `--json`) pass a logger that writes
+   * to stderr so stdout stays pure.
+   */
+  logger?: Logger;
 }
 
 export function createComputeModule(config: ComputeModuleConfig): ComputeModule {


### PR DESCRIPTION
Big consolidated CLI PR for the agent-driven deploy path. Targets `release/v1.0.0`.

## Tickets included

| Ticket | What |
|---|---|
| **[RND-589](https://linear.app/eigenlabs/issue/RND-589)** (supersedes [RND-564](https://linear.app/eigenlabs/issue/RND-564), [RND-571](https://linear.app/eigenlabs/issue/RND-571)) | Non-interactive deploy/upgrade: default safe flags, error all-at-once on required ones |
| **[RND-592](https://linear.app/eigenlabs/issue/RND-592)** | `app status [--wait] [--json]` so agents stop tight-looping `app info` |
| **[RND-591](https://linear.app/eigenlabs/issue/RND-591)** | Distinct exit codes for deploy/upgrade failure stages |
| **[RND-597](https://linear.app/eigenlabs/issue/RND-597)** | Harden amd64 enforcement: close assume-amd64 hole, pre-flight platform check, prebuilt-image arch check |
| **[RND-596](https://linear.app/eigenlabs/issue/RND-596)** | Block deploy/upgrade when wallet ETH < estimated gas (credits don't pay on-chain gas) |
| **[RND-567](https://linear.app/eigenlabs/issue/RND-567) / [568](https://linear.app/eigenlabs/issue/RND-568) / [569](https://linear.app/eigenlabs/issue/RND-569)** (folded from PR #162) | billing-cancel commonFlags; bounded upgrade & deploy watch with timeout + `WatchTimeoutError` |

## Highlights

**Non-interactive ([RND-589](https://linear.app/eigenlabs/issue/RND-589))**
- `isNonInteractive()` = `--non-interactive` flag › `CI=true` › `!isTTY`; new `--non-interactive` common flag.
- Defaults in non-TTY (logged): `--instance-type` → `g1-standard-2s` (deploy) / pinned type (upgrade), `--log-visibility` → private, `--resource-usage-monitoring` → disable, `--env-file` → `.env`-or-none.
- All-at-once error listing every missing required input (image source + name/app-id).
- `--environment` → `mainnet-alpha` on prod builds; version-check hook no-ops non-interactively; env bindings `ECLOUD_FORCE` / `ECLOUD_APP_ID`.
- `confirmWithDefault` returns its default in non-TTY instead of throwing (mainnet confirm stays safe: gated on `!force`, defaults to cancel).

**`app status` ([RND-592](https://linear.app/eigenlabs/issue/RND-592))**
- One-shot via `getStatuses`; `--json` → `{appId,status}`. `--wait` blocks via the bounded watch machinery (honors `--watch-timeout`/`ECLOUD_WATCH_TIMEOUT_SECONDS`), catches `WatchTimeoutError` with a recovery hint, then prints a final read.
- `requestWithRetry` now retries `502/503/504` in addition to `429`.
- Agent SKILL.md: use `status --wait`, do not loop `app info`.

**Exit codes ([RND-591](https://linear.app/eigenlabs/issue/RND-591))**
- `2` = invalid/missing input (pre-build), `3` = build/push failed (no on-chain tx), `4` = build OK but on-chain failed (image already pushed; re-run reuses it). Documented in SKILL.md.

**amd64 enforcement ([RND-597](https://linear.app/eigenlabs/issue/RND-597))**
- `digest.ts`: undetectable-architecture branch now throws instead of assuming amd64 (fail closed).
- `prepare.ts`: verify a remote `--image-ref` is linux/amd64 **before** the slow pull+layer+push (fails in ~seconds, not minutes).
- `dockerhub.ts`: `resolveDockerHubImageDigest` (prebuilt verifiable images) rejects a tag with no linux/amd64 manifest.
- `--verifiable --repo --commit` unchanged (server-side build).

**Gas pre-flight ([RND-596](https://linear.app/eigenlabs/issue/RND-596))**
- New `InsufficientGasError` + `assertSufficientGas` in the SDK, called at all 4 `prepare*` gas-estimate sites — so deploy/upgrade throw on **both CLI and SDK/agent** paths when wallet ETH < `gasEstimate.maxCostWei` (threshold is the estimate, not zero).
- `billing status` shows the wallet's on-chain ETH so the credit-vs-gas gap is visible pre-deploy.

## Testing

- [x] 113 CLI + 45 SDK unit tests pass; `eslint` + `prettier` clean
- [x] E2E sepolia-dev: headless deploy with only `--image-ref` + `--name` → all flags defaulted, on-chain createApp, app `STARTED`
- [x] E2E: missing inputs → one all-at-once error, **exit 2**
- [x] E2E: bad image → build fails, **exit 3**
- [x] E2E: valid image + bad nonce → built+pushed then on-chain fails, **exit 4** with reuse hint
- [x] E2E: `app status --json` and `--wait` (timeout + final read)
- [x] E2E: arm64 `--image-ref` rejected pre-push in ~16s with remediation ([RND-597](https://linear.app/eigenlabs/issue/RND-597)); amd64 passes pre-flight
- [x] E2E: 0.0044-ETH wallet blocked with `needs ~0.0198 ETH ... credits do not pay on-chain gas` ([RND-596](https://linear.app/eigenlabs/issue/RND-596)); `billing status` shows the ETH line
- [x] mainnet-alpha prod default locked in by unit test (no live mainnet deploy)
- [x] Rebased onto `release/v1.0.0` (carries the v1.4/v1.5 ContainerPolicy ABI fix #165)

## Supersedes / closes
- Closes **[RND-564](https://linear.app/eigenlabs/issue/RND-564)**, **[RND-571](https://linear.app/eigenlabs/issue/RND-571)** (duplicates of [RND-589](https://linear.app/eigenlabs/issue/RND-589)).
- Folds in **PR #162** ([RND-567](https://linear.app/eigenlabs/issue/RND-567)/[568](https://linear.app/eigenlabs/issue/RND-568)/[569](https://linear.app/eigenlabs/issue/RND-569)) — that PR can be closed in favor of this one.

### Out of scope
- [RND-572](https://linear.app/eigenlabs/issue/RND-572) (`--verifiable`+`--dockerfile`).
- "App entered Failed state" in E2E is TEE provisioning of the bare-nginx test image — unrelated.

## Review follow-ups (post-initial-review)
Hardening and cleanup from a follow-up review pass:

- **Non-interactive decision is now injected, not re-derived.** The optional-input helpers (`getDockerfile`, `getEnvFile`, `getLogSettings`, `getResourceUsageMonitoring`, `getInstanceType`) take the resolved `isNonInteractive(flags)` boolean as a parameter instead of recomputing it from `process` internally. Fixes a latent bug where `--non-interactive` on a TTY (with `CI` unset) was ignored, and keeps the helpers pure/unit-testable. Dropped the now-misleading `Interactive` suffix from these dual-mode helpers.
- **Exit-code classification fixes.** Extracted a pure `stageFailure(operation, stage, err)` mapping (removing the duplicated `this.error(..., { exit })` blocks across deploy/upgrade). Two corrections: an insufficient-gas failure is now **exit 4** (the image is already built+pushed) instead of being mislabeled **exit 3** "no deployment attempted"; and non-interactive `--dockerfile` without `--image-ref` is now reported up front as **exit 2** instead of throwing an unclassified **exit 1** at an interactive prompt.
- **`billing status`** now warns (with the reason) when the wallet-ETH read fails instead of silently swallowing it; still best-effort and never aborts the command.
- **Unified amd64 remediation text.** The platform-rejection message for a plain `--image-ref` (`digest.ts`) now matches the prebuilt path (`dockerhub.ts`): both recommend `docker buildx ... --push` **and** the server-side `--verifiable --repo <repo> --commit <sha>` escape hatch (most useful for arm64 hosts — no local Docker). Previously the plain path still said `docker build` / "use the SDK".
- **`app status --wait` returns immediately on settled statuses.** The command now does a one-shot read first and only blocks while the app is in a transitional status (`Created`/`Deploying`/`Upgrading`/`Resuming`/`Stopping`/`Terminating`), matched case-insensitively. Settled statuses (`Running`/`Stopped`/`Terminated`/`Suspended`/`Failed`) return right away instead of polling until the watch timeout. Additionally, `--wait --json` no longer corrupts its output: the SDK compute module accepts a logger override, and the command routes SDK progress (`Waiting for app to start...`, `Status: ...`) to stderr in JSON mode so stdout stays a single JSON object.
- **Cleanup:** explicit type annotations on declare-then-assign locals in deploy/upgrade; extracted the byte-identical `fetchAvailableInstanceTypes` into a shared `utils/instanceTypes.ts`.

All CLI/SDK unit tests pass (117 CLI + 45 SDK); `eslint` + `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




