### PR TITLE
fix(sdk): per-environment AppController Release ABI (v1.4 + v1.5) — unblocks sepolia-dev without breaking prod

### DIFF
--- a/packages/sdk/src/client/common/abis/AppController.json
+++ b/packages/sdk/src/client/common/abis/AppController.json
@@ -137,6 +137,19 @@
   },
   {
     "type": "function",
+    "name": "confirmUpgrade",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "createApp",
     "inputs": [
       {
@@ -187,6 +200,62 @@
             "name": "encryptedEnv",
             "type": "bytes",
             "internalType": "bytes"
+          },
+          {
+            "name": "containerPolicy",
+            "type": "tuple",
+            "internalType": "structIAppController.ContainerPolicy",
+            "components": [
+              {
+                "name": "args",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "cmdOverride",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "env",
+                "type": "tuple[]",
+                "internalType": "structIAppController.EnvVar[]",
+                "components": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "envOverride",
+                "type": "tuple[]",
+                "internalType": "structIAppController.EnvVar[]",
+                "components": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "restartPolicy",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           }
         ]
       }
@@ -252,8 +321,102 @@
             "name": "encryptedEnv",
             "type": "bytes",
             "internalType": "bytes"
+          },
+          {
+            "name": "containerPolicy",
+            "type": "tuple",
+            "internalType": "structIAppController.ContainerPolicy",
+            "components": [
+              {
+                "name": "args",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "cmdOverride",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "env",
+                "type": "tuple[]",
+                "internalType": "structIAppController.EnvVar[]",
+                "components": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "envOverride",
+                "type": "tuple[]",
+                "internalType": "structIAppController.EnvVar[]",
+                "components": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "restartPolicy",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           }
         ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "createEmptyApp",
+    "inputs": [
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "createEmptyAppWithIsolatedBilling",
+    "inputs": [
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
     "outputs": [
@@ -299,25 +462,6 @@
   },
   {
     "type": "function",
-    "name": "getBillingType",
-    "inputs": [
-      {
-        "name": "app",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint8",
-        "internalType": "uint8"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "getAppCreator",
     "inputs": [
       {
@@ -357,6 +501,25 @@
   {
     "type": "function",
     "name": "getAppOperatorSetId",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppPendingReleaseBlockNumber",
     "inputs": [
       {
         "name": "app",
@@ -434,6 +597,11 @@
             "internalType": "uint32"
           },
           {
+            "name": "pendingReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
             "name": "status",
             "type": "uint8",
             "internalType": "enumIAppController.AppStatus"
@@ -486,6 +654,11 @@
           },
           {
             "name": "latestReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "pendingReleaseBlockNumber",
             "type": "uint32",
             "internalType": "uint32"
           },
@@ -546,6 +719,11 @@
             "internalType": "uint32"
           },
           {
+            "name": "pendingReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
             "name": "status",
             "type": "uint8",
             "internalType": "enumIAppController.AppStatus"
@@ -602,11 +780,54 @@
             "internalType": "uint32"
           },
           {
+            "name": "pendingReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
             "name": "status",
             "type": "uint8",
             "internalType": "enumIAppController.AppStatus"
           }
         ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBillingAccount",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBillingType",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enumIAppController.BillingType"
       }
     ],
     "stateMutability": "view"
@@ -866,6 +1087,62 @@
             "name": "encryptedEnv",
             "type": "bytes",
             "internalType": "bytes"
+          },
+          {
+            "name": "containerPolicy",
+            "type": "tuple",
+            "internalType": "structIAppController.ContainerPolicy",
+            "components": [
+              {
+                "name": "args",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "cmdOverride",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "env",
+                "type": "tuple[]",
+                "internalType": "structIAppController.EnvVar[]",
+                "components": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "envOverride",
+                "type": "tuple[]",
+                "internalType": "structIAppController.EnvVar[]",
+                "components": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "restartPolicy",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           }
         ]
       }
@@ -1061,6 +1338,62 @@
             "name": "encryptedEnv",
             "type": "bytes",
             "internalType": "bytes"
+          },
+          {
+            "name": "containerPolicy",
+            "type": "tuple",
+            "internalType": "structIAppController.ContainerPolicy",
+            "components": [
+              {
+                "name": "args",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "cmdOverride",
+                "type": "string[]",
+                "internalType": "string[]"
+              },
+              {
+                "name": "env",
+                "type": "tuple[]",
+                "internalType": "structIAppController.EnvVar[]",
+                "components": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "envOverride",
+                "type": "tuple[]",
+                "internalType": "structIAppController.EnvVar[]",
+                "components": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "restartPolicy",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
           }
         ]
       }
@@ -1105,6 +1438,25 @@
       },
       {
         "name": "limit",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UpgradeConfirmed",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      },
+      {
+        "name": "pendingReleaseBlockNumber",
         "type": "uint32",
         "indexed": false,
         "internalType": "uint32"
@@ -1165,6 +1517,11 @@
   {
     "type": "error",
     "name": "MoreThanOneArtifact",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoPendingUpgrade",
     "inputs": []
   },
   {

--- a/packages/sdk/src/client/common/abis/AppController.v1_4.json
+++ b/packages/sdk/src/client/common/abis/AppController.v1_4.json
@@ -1,0 +1,1186 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_version",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "_permissionController",
+        "type": "address",
+        "internalType": "contractIPermissionController"
+      },
+      {
+        "name": "_releaseManager",
+        "type": "address",
+        "internalType": "contractIReleaseManager"
+      },
+      {
+        "name": "_computeAVSRegistrar",
+        "type": "address",
+        "internalType": "contractIComputeAVSRegistrar"
+      },
+      {
+        "name": "_computeOperator",
+        "type": "address",
+        "internalType": "contractIComputeOperator"
+      },
+      {
+        "name": "_appBeacon",
+        "type": "address",
+        "internalType": "contractIBeacon"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "API_PERMISSION_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "appBeacon",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contractIBeacon"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "calculateApiPermissionDigestHash",
+    "inputs": [
+      {
+        "name": "permission",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      },
+      {
+        "name": "expiry",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "calculateAppId",
+    "inputs": [
+      {
+        "name": "deployer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeAVSRegistrar",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contractIComputeAVSRegistrar"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeOperator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contractIComputeOperator"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "createApp",
+    "inputs": [
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "release",
+        "type": "tuple",
+        "internalType": "structIAppController.Release",
+        "components": [
+          {
+            "name": "rmsRelease",
+            "type": "tuple",
+            "internalType": "structIReleaseManagerTypes.Release",
+            "components": [
+              {
+                "name": "artifacts",
+                "type": "tuple[]",
+                "internalType": "structIReleaseManagerTypes.Artifact[]",
+                "components": [
+                  {
+                    "name": "digest",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "registry",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "upgradeByTime",
+                "type": "uint32",
+                "internalType": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "publicEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "encryptedEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "createAppWithIsolatedBilling",
+    "inputs": [
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "release",
+        "type": "tuple",
+        "internalType": "structIAppController.Release",
+        "components": [
+          {
+            "name": "rmsRelease",
+            "type": "tuple",
+            "internalType": "structIReleaseManagerTypes.Release",
+            "components": [
+              {
+                "name": "artifacts",
+                "type": "tuple[]",
+                "internalType": "structIReleaseManagerTypes.Artifact[]",
+                "components": [
+                  {
+                    "name": "digest",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "registry",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "upgradeByTime",
+                "type": "uint32",
+                "internalType": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "publicEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "encryptedEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "domainSeparator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getActiveAppCount",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBillingType",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppCreator",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppLatestReleaseBlockNumber",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppOperatorSetId",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppStatus",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enumIAppController.AppStatus"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getApps",
+    "inputs": [
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "apps",
+        "type": "address[]",
+        "internalType": "contractIApp[]"
+      },
+      {
+        "name": "appConfigsMem",
+        "type": "tuple[]",
+        "internalType": "structIAppController.AppConfig[]",
+        "components": [
+          {
+            "name": "creator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operatorSetId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "latestReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enumIAppController.AppStatus"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppsByBillingAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "apps",
+        "type": "address[]",
+        "internalType": "contractIApp[]"
+      },
+      {
+        "name": "appConfigsMem",
+        "type": "tuple[]",
+        "internalType": "structIAppController.AppConfig[]",
+        "components": [
+          {
+            "name": "creator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operatorSetId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "latestReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enumIAppController.AppStatus"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppsByCreator",
+    "inputs": [
+      {
+        "name": "creator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "apps",
+        "type": "address[]",
+        "internalType": "contractIApp[]"
+      },
+      {
+        "name": "appConfigsMem",
+        "type": "tuple[]",
+        "internalType": "structIAppController.AppConfig[]",
+        "components": [
+          {
+            "name": "creator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operatorSetId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "latestReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enumIAppController.AppStatus"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAppsByDeveloper",
+    "inputs": [
+      {
+        "name": "developer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "apps",
+        "type": "address[]",
+        "internalType": "contractIApp[]"
+      },
+      {
+        "name": "appConfigsMem",
+        "type": "tuple[]",
+        "internalType": "structIAppController.AppConfig[]",
+        "components": [
+          {
+            "name": "creator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operatorSetId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "latestReleaseBlockNumber",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "status",
+            "type": "uint8",
+            "internalType": "enumIAppController.AppStatus"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMaxActiveAppsPerUser",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "globalActiveAppCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "admin",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "maxGlobalActiveApps",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permissionController",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contractIPermissionController"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "releaseManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contractIReleaseManager"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setMaxActiveAppsPerUser",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "limit",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMaxGlobalActiveApps",
+    "inputs": [
+      {
+        "name": "limit",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "startApp",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stopApp",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "suspend",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "apps",
+        "type": "address[]",
+        "internalType": "contractIApp[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "terminateApp",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "terminateAppByAdmin",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAppMetadataURI",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      },
+      {
+        "name": "metadataURI",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeApp",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "internalType": "contractIApp"
+      },
+      {
+        "name": "release",
+        "type": "tuple",
+        "internalType": "structIAppController.Release",
+        "components": [
+          {
+            "name": "rmsRelease",
+            "type": "tuple",
+            "internalType": "structIReleaseManagerTypes.Release",
+            "components": [
+              {
+                "name": "artifacts",
+                "type": "tuple[]",
+                "internalType": "structIReleaseManagerTypes.Artifact[]",
+                "components": [
+                  {
+                    "name": "digest",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "registry",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "upgradeByTime",
+                "type": "uint32",
+                "internalType": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "publicEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "encryptedEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "version",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "AppCreated",
+    "inputs": [
+      {
+        "name": "creator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      },
+      {
+        "name": "operatorSetId",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppMetadataURIUpdated",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      },
+      {
+        "name": "metadataURI",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppStarted",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppStopped",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppSuspended",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppTerminated",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppTerminatedByAdmin",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppUpgraded",
+    "inputs": [
+      {
+        "name": "app",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contractIApp"
+      },
+      {
+        "name": "rmsReleaseId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "release",
+        "type": "tuple",
+        "indexed": false,
+        "internalType": "structIAppController.Release",
+        "components": [
+          {
+            "name": "rmsRelease",
+            "type": "tuple",
+            "internalType": "structIReleaseManagerTypes.Release",
+            "components": [
+              {
+                "name": "artifacts",
+                "type": "tuple[]",
+                "internalType": "structIReleaseManagerTypes.Artifact[]",
+                "components": [
+                  {
+                    "name": "digest",
+                    "type": "bytes32",
+                    "internalType": "bytes32"
+                  },
+                  {
+                    "name": "registry",
+                    "type": "string",
+                    "internalType": "string"
+                  }
+                ]
+              },
+              {
+                "name": "upgradeByTime",
+                "type": "uint32",
+                "internalType": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "publicEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "encryptedEnv",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "GlobalMaxActiveAppsSet",
+    "inputs": [
+      {
+        "name": "limit",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxActiveAppsSet",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "limit",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AccountHasActiveApps",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AppAlreadyExists",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AppDoesNotExist",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "GlobalMaxActiveAppsExceeded",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidAppStatus",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPermissions",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidReleaseMetadataURI",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidShortString",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxActiveAppsExceeded",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MoreThanOneArtifact",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SignatureExpired",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "StringTooLong",
+    "inputs": [
+      {
+        "name": "str",
+        "type": "string",
+        "internalType": "string"
+      }
+    ]
+  }
+]

--- a/packages/sdk/src/client/common/config/environment.ts
+++ b/packages/sdk/src/client/common/config/environment.ts
@@ -2,7 +2,6 @@
  * Environment configuration for different networks
  */
 
-import { Address } from "viem";
 import { BillingEnvironmentConfig, EnvironmentConfig } from "../types";
 
 // Chain IDs
@@ -41,6 +40,7 @@ const ENVIRONMENTS: Record<string, Omit<EnvironmentConfig, "chainID">> = {
     name: "sepolia",
     build: "dev",
     appControllerAddress: "0xa86DC1C47cb2518327fB4f9A1627F51966c83B92",
+    releaseAbiVersion: "v1.5", // AppController upgraded to v1.5.x (containerPolicy)
     permissionControllerAddress: ChainAddresses[SEPOLIA_CHAIN_ID].PermissionController,
     erc7702DelegatorAddress: CommonAddresses.ERC7702Delegator,
     kmsServerURL: "http://10.128.0.57:8080",
@@ -54,6 +54,7 @@ const ENVIRONMENTS: Record<string, Omit<EnvironmentConfig, "chainID">> = {
     name: "sepolia",
     build: "prod",
     appControllerAddress: "0x0dd810a6ffba6a9820a10d97b659f07d8d23d4E2",
+    releaseAbiVersion: "v1.4", // prod still on AppController v1.4.0 (3-field Release)
     permissionControllerAddress: ChainAddresses[SEPOLIA_CHAIN_ID].PermissionController,
     erc7702DelegatorAddress: CommonAddresses.ERC7702Delegator,
     kmsServerURL: "http://10.128.15.203:8080",
@@ -68,6 +69,7 @@ const ENVIRONMENTS: Record<string, Omit<EnvironmentConfig, "chainID">> = {
     name: "mainnet-alpha",
     build: "prod",
     appControllerAddress: "0xc38d35Fc995e75342A21CBd6D770305b142Fbe67",
+    releaseAbiVersion: "v1.4", // prod still on AppController v1.4.0 (3-field Release)
     permissionControllerAddress: ChainAddresses[MAINNET_CHAIN_ID].PermissionController,
     erc7702DelegatorAddress: CommonAddresses.ERC7702Delegator,
     kmsServerURL: "http://10.128.0.2:8080",

--- a/packages/sdk/src/client/common/contract/caller.ts
+++ b/packages/sdk/src/client/common/contract/caller.ts
@@ -34,8 +34,30 @@ import {
 import { Release, ContainerPolicy, EMPTY_CONTAINER_POLICY } from "../types";
 import { getChainFromID } from "../utils/helpers";
 
-import AppControllerABI from "../abis/AppController.json";
+// The on-chain AppController `Release` struct differs by contract version:
+//   v1.4.x (sepolia, mainnet-alpha): 3-field Release
+//   v1.5.x (sepolia-dev):            4-field Release (+ containerPolicy, KMS-006)
+// The two ABIs also diverge on createApp/upgradeApp selectors and getApps
+// AppConfig shape, so we select the whole ABI by environment version.
+import AppControllerABIv1_5 from "../abis/AppController.json";
+import AppControllerABIv1_4 from "../abis/AppController.v1_4.json";
 import PermissionControllerABI from "../abis/PermissionController.json";
+
+/**
+ * Select the AppController ABI matching the environment's deployed contract
+ * version. Defaults to the latest (v1.5) when a config omits the field, so
+ * new environments opt into older behavior explicitly.
+ */
+function appControllerAbiFor(environmentConfig: EnvironmentConfig) {
+  return environmentConfig.releaseAbiVersion === "v1.4"
+    ? AppControllerABIv1_4
+    : AppControllerABIv1_5;
+}
+
+/** Whether this environment's Release struct carries the v1.5+ containerPolicy field. */
+function supportsContainerPolicy(environmentConfig: EnvironmentConfig): boolean {
+  return environmentConfig.releaseAbiVersion !== "v1.4";
+}
 
 /**
  * Build the viem-encodable `containerPolicy` tuple for the AppController
@@ -50,6 +72,28 @@ function containerPolicyForViem(policy: ContainerPolicy = EMPTY_CONTAINER_POLICY
     envOverride: policy.envOverride.map((e) => ({ key: e.key, value: e.value })),
     restartPolicy: policy.restartPolicy,
   };
+}
+
+/**
+ * Build the viem-encodable `release` tuple for createApp/upgradeApp, including
+ * the v1.5+ `containerPolicy` field only when the target contract expects it.
+ */
+function releaseForViem(release: Release, environmentConfig: EnvironmentConfig) {
+  const base = {
+    rmsRelease: {
+      artifacts: release.rmsRelease.artifacts.map((artifact) => ({
+        digest: `0x${bytesToHex(artifact.digest).slice(2).padStart(64, "0")}` as Hex,
+        registry: artifact.registry,
+      })),
+      upgradeByTime: release.rmsRelease.upgradeByTime,
+    },
+    publicEnv: bytesToHex(release.publicEnv) as Hex,
+    encryptedEnv: bytesToHex(release.encryptedEnv) as Hex,
+  };
+  if (!supportsContainerPolicy(environmentConfig)) {
+    return base;
+  }
+  return { ...base, containerPolicy: containerPolicyForViem(release.containerPolicy) };
 }
 
 /**
@@ -202,7 +246,7 @@ export async function calculateAppID(options: CalculateAppIDOptions): Promise<Ad
 
   const appID = await publicClient.readContract({
     address: environmentConfig.appControllerAddress as Address,
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "calculateAppId",
     args: [ownerAddress, saltHex],
   });
@@ -258,25 +302,15 @@ export async function prepareDeployBatch(
   const paddedSaltHex = saltHexString.padStart(64, "0");
   const saltHex = `0x${paddedSaltHex}` as Hex;
 
-  // Convert Release Uint8Array values to hex strings for viem
-  const releaseForViem = {
-    rmsRelease: {
-      artifacts: release.rmsRelease.artifacts.map((artifact) => ({
-        digest: `0x${bytesToHex(artifact.digest).slice(2).padStart(64, "0")}` as Hex,
-        registry: artifact.registry,
-      })),
-      upgradeByTime: release.rmsRelease.upgradeByTime,
-    },
-    publicEnv: bytesToHex(release.publicEnv) as Hex,
-    encryptedEnv: bytesToHex(release.encryptedEnv) as Hex,
-    containerPolicy: containerPolicyForViem(release.containerPolicy),
-  };
+  // Convert Release Uint8Array values to hex strings for viem (version-aware:
+  // includes containerPolicy only on v1.5+ contracts).
+  const release_ = releaseForViem(release, environmentConfig);
 
   const functionName = options.billTo === "app" ? "createAppWithIsolatedBilling" : "createApp";
   const createData = encodeFunctionData({
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName,
-    args: [saltHex, releaseForViem],
+    args: [saltHex, release_],
   });
 
   // 3. Pack accept admin call
@@ -754,25 +788,13 @@ export async function prepareUpgradeBatch(
     needsPermissionChange,
   } = options;
 
-  // 1. Pack upgrade app call
-  // Convert Release Uint8Array values to hex strings for viem
-  const releaseForViem = {
-    rmsRelease: {
-      artifacts: release.rmsRelease.artifacts.map((artifact) => ({
-        digest: `0x${bytesToHex(artifact.digest).slice(2).padStart(64, "0")}` as Hex,
-        registry: artifact.registry,
-      })),
-      upgradeByTime: release.rmsRelease.upgradeByTime,
-    },
-    publicEnv: bytesToHex(release.publicEnv) as Hex,
-    encryptedEnv: bytesToHex(release.encryptedEnv) as Hex,
-    containerPolicy: containerPolicyForViem(release.containerPolicy),
-  };
+  // 1. Pack upgrade app call (version-aware Release encoding).
+  const release_ = releaseForViem(release, environmentConfig);
 
   const upgradeData = encodeFunctionData({
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "upgradeApp",
-    args: [appID, releaseForViem],
+    args: [appID, release_],
   });
 
   // 2. Start with upgrade execution
@@ -964,7 +986,7 @@ export async function sendAndWaitForTransaction(
       if (callError.data) {
         try {
           const decoded = decodeErrorResult({
-            abi: AppControllerABI,
+            abi: appControllerAbiFor(environmentConfig),
             data: callError.data,
           });
           const formattedError = formatAppControllerError(decoded);
@@ -1034,7 +1056,7 @@ export async function getActiveAppCount(
 ): Promise<number> {
   const count = await publicClient.readContract({
     address: environmentConfig.appControllerAddress,
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "getActiveAppCount",
     args: [user],
   });
@@ -1052,7 +1074,7 @@ export async function getMaxActiveAppsPerUser(
 ): Promise<number> {
   const quota = await publicClient.readContract({
     address: environmentConfig.appControllerAddress,
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "getMaxActiveAppsPerUser",
     args: [user],
   });
@@ -1077,7 +1099,7 @@ export async function getAppsByCreator(
 ): Promise<{ apps: Address[]; appConfigs: AppConfig[] }> {
   const result = (await publicClient.readContract({
     address: environmentConfig.appControllerAddress,
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "getAppsByCreator",
     args: [creator, offset, limit],
   })) as [Address[], AppConfig[]];
@@ -1101,7 +1123,7 @@ export async function getAppsByDeveloper(
 ): Promise<{ apps: Address[]; appConfigs: AppConfig[] }> {
   const result = (await publicClient.readContract({
     address: environmentConfig.appControllerAddress,
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "getAppsByDeveloper",
     args: [developer, offset, limit],
   })) as [Address[], AppConfig[]];
@@ -1123,7 +1145,7 @@ export async function getBillingType(
 ): Promise<number> {
   const result = await publicClient.readContract({
     address: environmentConfig.appControllerAddress,
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "getBillingType",
     args: [app],
   });
@@ -1142,7 +1164,7 @@ export async function getAppsByBillingAccount(
 ): Promise<{ apps: Address[]; appConfigs: AppConfig[] }> {
   const result = (await publicClient.readContract({
     address: environmentConfig.appControllerAddress,
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "getAppsByBillingAccount",
     args: [account, offset, limit],
   })) as [Address[], AppConfig[]];
@@ -1201,7 +1223,7 @@ export async function getAppLatestReleaseBlockNumbers(
       publicClient
         .readContract({
           address: environmentConfig.appControllerAddress,
-          abi: AppControllerABI,
+          abi: appControllerAbiFor(environmentConfig),
           functionName: "getAppLatestReleaseBlockNumber",
           args: [appID],
         })
@@ -1270,7 +1292,7 @@ export async function suspend(
   const { walletClient, publicClient, environmentConfig, account, apps } = options;
 
   const suspendData = encodeFunctionData({
-    abi: AppControllerABI,
+    abi: appControllerAbiFor(environmentConfig),
     functionName: "suspend",
     args: [account, apps],
   });

--- a/packages/sdk/src/client/common/contract/caller.ts
+++ b/packages/sdk/src/client/common/contract/caller.ts
@@ -31,11 +31,26 @@ import {
   DeployProgressCallback,
   SequentialDeployResult,
 } from "../types";
-import { Release } from "../types";
+import { Release, ContainerPolicy, EMPTY_CONTAINER_POLICY } from "../types";
 import { getChainFromID } from "../utils/helpers";
 
 import AppControllerABI from "../abis/AppController.json";
 import PermissionControllerABI from "../abis/PermissionController.json";
+
+/**
+ * Build the viem-encodable `containerPolicy` tuple for the AppController
+ * `Release` struct (v1.5.0+). Falls back to an empty policy when the caller
+ * does not supply one, which preserves the image's own entrypoint/env.
+ */
+function containerPolicyForViem(policy: ContainerPolicy = EMPTY_CONTAINER_POLICY) {
+  return {
+    args: policy.args,
+    cmdOverride: policy.cmdOverride,
+    env: policy.env.map((e) => ({ key: e.key, value: e.value })),
+    envOverride: policy.envOverride.map((e) => ({ key: e.key, value: e.value })),
+    restartPolicy: policy.restartPolicy,
+  };
+}
 
 /**
  * Gas estimation result
@@ -254,6 +269,7 @@ export async function prepareDeployBatch(
     },
     publicEnv: bytesToHex(release.publicEnv) as Hex,
     encryptedEnv: bytesToHex(release.encryptedEnv) as Hex,
+    containerPolicy: containerPolicyForViem(release.containerPolicy),
   };
 
   const functionName = options.billTo === "app" ? "createAppWithIsolatedBilling" : "createApp";
@@ -750,6 +766,7 @@ export async function prepareUpgradeBatch(
     },
     publicEnv: bytesToHex(release.publicEnv) as Hex,
     encryptedEnv: bytesToHex(release.encryptedEnv) as Hex,
+    containerPolicy: containerPolicyForViem(release.containerPolicy),
   };
 
   const upgradeData = encodeFunctionData({

--- a/packages/sdk/src/client/common/contract/env-abi-selection.test.ts
+++ b/packages/sdk/src/client/common/contract/env-abi-selection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { encodeFunctionData, type Hex } from "viem";
+import AppControllerABIv1_5 from "../abis/AppController.json";
+import AppControllerABIv1_4 from "../abis/AppController.v1_4.json";
+import { getEnvironmentConfig } from "../config/environment";
+import { EMPTY_CONTAINER_POLICY } from "../types";
+
+// Mirror caller.ts selection logic to assert config wires the right ABI per env.
+function abiFor(v?: string) {
+  return v === "v1.4" ? AppControllerABIv1_4 : AppControllerABIv1_5;
+}
+
+describe("env -> AppController ABI selection", () => {
+  const rms = {
+    artifacts: [{ digest: `0x${"11".repeat(32)}` as Hex, registry: "r" }],
+    upgradeByTime: 4_000_000_000,
+  };
+  const origBuild = process.env.BUILD_TYPE;
+  const cases: Array<[string, string, string]> = [["sepolia-dev", "dev", "0x5e92a19f"]];
+  for (const [env, build, sel] of cases) {
+    it(`${env} selects selector ${sel}`, () => {
+      process.env.BUILD_TYPE = build;
+      const cfg = getEnvironmentConfig(env);
+      const abi = abiFor(cfg.releaseAbiVersion);
+      const rel =
+        cfg.releaseAbiVersion === "v1.4"
+          ? { rmsRelease: rms, publicEnv: "0x" as Hex, encryptedEnv: "0x" as Hex }
+          : {
+              rmsRelease: rms,
+              publicEnv: "0x" as Hex,
+              encryptedEnv: "0x" as Hex,
+              containerPolicy: EMPTY_CONTAINER_POLICY,
+            };
+      const data = encodeFunctionData({
+        abi,
+        functionName: "createApp",
+        args: [`0x${"22".repeat(32)}` as Hex, rel],
+      });
+      expect(data.slice(0, 10)).toBe(sel);
+      if (origBuild === undefined) delete process.env.BUILD_TYPE;
+      else process.env.BUILD_TYPE = origBuild;
+    });
+  }
+  it("prod envs are pinned to v1.4", () => {
+    process.env.BUILD_TYPE = "prod";
+    expect(getEnvironmentConfig("sepolia").releaseAbiVersion).toBe("v1.4");
+    expect(getEnvironmentConfig("mainnet-alpha").releaseAbiVersion).toBe("v1.4");
+    if (origBuild === undefined) delete process.env.BUILD_TYPE;
+    else process.env.BUILD_TYPE = origBuild;
+  });
+});

--- a/packages/sdk/src/client/common/contract/release-encoding.test.ts
+++ b/packages/sdk/src/client/common/contract/release-encoding.test.ts
@@ -1,93 +1,109 @@
 import { describe, expect, it } from "vitest";
 import { decodeFunctionData, encodeFunctionData, type Hex } from "viem";
-import AppControllerABI from "../abis/AppController.json";
+import AppControllerABIv1_5 from "../abis/AppController.json";
+import AppControllerABIv1_4 from "../abis/AppController.v1_4.json";
 import { EMPTY_CONTAINER_POLICY, type ContainerPolicy } from "../types";
 
 /**
- * Regression guard for the AppController v1.5.x `Release` ABI.
+ * Regression guard for the per-environment AppController `Release` ABI.
  *
- * v1.5.0 (eigenx-contracts KMS-006) added a 4th field `containerPolicy` to the
- * on-chain `Release` struct, which changed the `createApp` selector from
- * 0xa60daa8f to 0x5e92a19f. The SDK had shipped the 3-field ABI, so every
- * deploy/upgrade encoded the old selector and reverted with empty data against
- * the upgraded contract. These tests pin the new selectors and the 4-field
- * encoding so the drift cannot silently return.
+ * v1.5.x (sepolia-dev) added a 4th field `containerPolicy` to the on-chain
+ * `Release` struct (eigenx-contracts KMS-006), changing the `createApp`
+ * selector from 0xa60daa8f to 0x5e92a19f. v1.4.x (sepolia, mainnet-alpha) is
+ * still on the 3-field struct. The SDK ships both ABIs and selects per
+ * environment, so both shapes must keep encoding to their respective selectors.
  */
-describe("AppController Release encoding (v1.5.x containerPolicy)", () => {
-  const sampleRelease = (containerPolicy?: ContainerPolicy) => ({
-    rmsRelease: {
-      artifacts: [{ digest: `0x${"11".repeat(32)}` as Hex, registry: "docker.io/acme/app" }],
-      upgradeByTime: 4_000_000_000,
-    },
-    publicEnv: "0x" as Hex,
-    encryptedEnv: "0x" as Hex,
-    containerPolicy: containerPolicy ?? EMPTY_CONTAINER_POLICY,
-  });
-
+describe("AppController Release encoding (per-version)", () => {
   const SALT = `0x${"22".repeat(32)}` as Hex;
   const APP = `0x${"33".repeat(20)}` as Hex;
+  const rmsRelease = {
+    artifacts: [{ digest: `0x${"11".repeat(32)}` as Hex, registry: "docker.io/acme/app" }],
+    upgradeByTime: 4_000_000_000,
+  };
+  const release3 = { rmsRelease, publicEnv: "0x" as Hex, encryptedEnv: "0x" as Hex };
+  const release4 = { ...release3, containerPolicy: EMPTY_CONTAINER_POLICY };
 
-  it("encodes createApp with the v1.5.x selector (4-field Release)", () => {
-    const data = encodeFunctionData({
-      abi: AppControllerABI,
-      functionName: "createApp",
-      args: [SALT, sampleRelease()],
-    });
-    expect(data.slice(0, 10)).toBe("0x5e92a19f");
-  });
-
-  it("encodes createAppWithIsolatedBilling and upgradeApp without throwing", () => {
-    expect(() =>
-      encodeFunctionData({
-        abi: AppControllerABI,
-        functionName: "createAppWithIsolatedBilling",
-        args: [SALT, sampleRelease()],
-      }),
-    ).not.toThrow();
-    expect(() =>
-      encodeFunctionData({
-        abi: AppControllerABI,
-        functionName: "upgradeApp",
-        args: [APP, sampleRelease()],
-      }),
-    ).not.toThrow();
-  });
-
-  it("round-trips the containerPolicy field through the ABI", () => {
-    const policy: ContainerPolicy = {
-      args: ["--flag"],
-      cmdOverride: ["/bin/run"],
-      env: [{ key: "FOO", value: "bar" }],
-      envOverride: [],
-      restartPolicy: "always",
-    };
-    const data = encodeFunctionData({
-      abi: AppControllerABI,
-      functionName: "createApp",
-      args: [SALT, sampleRelease(policy)],
-    });
-    const { args } = decodeFunctionData({ abi: AppControllerABI, data });
-    // args = [salt, release]; release.containerPolicy is the 4th tuple field
-    const release = args![1] as { containerPolicy: ContainerPolicy };
-    expect(release.containerPolicy).toEqual(policy);
-  });
-
-  it("keeps the old 3-field selector out of the ABI (drift guard)", () => {
-    expect(() =>
-      // The pre-v1.5.0 3-field Release shape must no longer encode against this ABI.
-      encodeFunctionData({
-        abi: AppControllerABI,
+  describe("v1.5 (4-field, sepolia-dev)", () => {
+    it("encodes createApp with the v1.5 selector", () => {
+      const data = encodeFunctionData({
+        abi: AppControllerABIv1_5,
         functionName: "createApp",
-        args: [
-          SALT,
-          {
-            rmsRelease: { artifacts: [], upgradeByTime: 0 },
-            publicEnv: "0x" as Hex,
-            encryptedEnv: "0x" as Hex,
-            // containerPolicy intentionally omitted -> viem must reject the arity
-          },
-        ],
-      }),
-    ).toThrow();
+        args: [SALT, release4],
+      });
+      expect(data.slice(0, 10)).toBe("0x5e92a19f");
+    });
+
+    it("encodes createAppWithIsolatedBilling and upgradeApp without throwing", () => {
+      expect(() =>
+        encodeFunctionData({
+          abi: AppControllerABIv1_5,
+          functionName: "createAppWithIsolatedBilling",
+          args: [SALT, release4],
+        }),
+      ).not.toThrow();
+      expect(() =>
+        encodeFunctionData({
+          abi: AppControllerABIv1_5,
+          functionName: "upgradeApp",
+          args: [APP, release4],
+        }),
+      ).not.toThrow();
+    });
+
+    it("round-trips the containerPolicy field", () => {
+      const policy: ContainerPolicy = {
+        args: ["--flag"],
+        cmdOverride: ["/bin/run"],
+        env: [{ key: "FOO", value: "bar" }],
+        envOverride: [],
+        restartPolicy: "always",
+      };
+      const data = encodeFunctionData({
+        abi: AppControllerABIv1_5,
+        functionName: "createApp",
+        args: [SALT, { ...release3, containerPolicy: policy }],
+      });
+      const { args } = decodeFunctionData({ abi: AppControllerABIv1_5, data });
+      const release = args![1] as { containerPolicy: ContainerPolicy };
+      expect(release.containerPolicy).toEqual(policy);
+    });
+
+    it("rejects the 3-field shape (arity guard)", () => {
+      expect(() =>
+        encodeFunctionData({
+          abi: AppControllerABIv1_5,
+          functionName: "createApp",
+          args: [SALT, release3],
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("v1.4 (3-field, sepolia / mainnet-alpha)", () => {
+    it("encodes createApp with the legacy selector", () => {
+      const data = encodeFunctionData({
+        abi: AppControllerABIv1_4,
+        functionName: "createApp",
+        args: [SALT, release3],
+      });
+      expect(data.slice(0, 10)).toBe("0xa60daa8f");
+    });
+
+    it("encodes createAppWithIsolatedBilling and upgradeApp without throwing", () => {
+      expect(() =>
+        encodeFunctionData({
+          abi: AppControllerABIv1_4,
+          functionName: "createAppWithIsolatedBilling",
+          args: [SALT, release3],
+        }),
+      ).not.toThrow();
+      expect(() =>
+        encodeFunctionData({
+          abi: AppControllerABIv1_4,
+          functionName: "upgradeApp",
+          args: [APP, release3],
+        }),
+      ).not.toThrow();
+    });
   });
 });

--- a/packages/sdk/src/client/common/contract/release-encoding.test.ts
+++ b/packages/sdk/src/client/common/contract/release-encoding.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { decodeFunctionData, encodeFunctionData, type Hex } from "viem";
+import AppControllerABI from "../abis/AppController.json";
+import { EMPTY_CONTAINER_POLICY, type ContainerPolicy } from "../types";
+
+/**
+ * Regression guard for the AppController v1.5.x `Release` ABI.
+ *
+ * v1.5.0 (eigenx-contracts KMS-006) added a 4th field `containerPolicy` to the
+ * on-chain `Release` struct, which changed the `createApp` selector from
+ * 0xa60daa8f to 0x5e92a19f. The SDK had shipped the 3-field ABI, so every
+ * deploy/upgrade encoded the old selector and reverted with empty data against
+ * the upgraded contract. These tests pin the new selectors and the 4-field
+ * encoding so the drift cannot silently return.
+ */
+describe("AppController Release encoding (v1.5.x containerPolicy)", () => {
+  const sampleRelease = (containerPolicy?: ContainerPolicy) => ({
+    rmsRelease: {
+      artifacts: [{ digest: `0x${"11".repeat(32)}` as Hex, registry: "docker.io/acme/app" }],
+      upgradeByTime: 4_000_000_000,
+    },
+    publicEnv: "0x" as Hex,
+    encryptedEnv: "0x" as Hex,
+    containerPolicy: containerPolicy ?? EMPTY_CONTAINER_POLICY,
+  });
+
+  const SALT = `0x${"22".repeat(32)}` as Hex;
+  const APP = `0x${"33".repeat(20)}` as Hex;
+
+  it("encodes createApp with the v1.5.x selector (4-field Release)", () => {
+    const data = encodeFunctionData({
+      abi: AppControllerABI,
+      functionName: "createApp",
+      args: [SALT, sampleRelease()],
+    });
+    expect(data.slice(0, 10)).toBe("0x5e92a19f");
+  });
+
+  it("encodes createAppWithIsolatedBilling and upgradeApp without throwing", () => {
+    expect(() =>
+      encodeFunctionData({
+        abi: AppControllerABI,
+        functionName: "createAppWithIsolatedBilling",
+        args: [SALT, sampleRelease()],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      encodeFunctionData({
+        abi: AppControllerABI,
+        functionName: "upgradeApp",
+        args: [APP, sampleRelease()],
+      }),
+    ).not.toThrow();
+  });
+
+  it("round-trips the containerPolicy field through the ABI", () => {
+    const policy: ContainerPolicy = {
+      args: ["--flag"],
+      cmdOverride: ["/bin/run"],
+      env: [{ key: "FOO", value: "bar" }],
+      envOverride: [],
+      restartPolicy: "always",
+    };
+    const data = encodeFunctionData({
+      abi: AppControllerABI,
+      functionName: "createApp",
+      args: [SALT, sampleRelease(policy)],
+    });
+    const { args } = decodeFunctionData({ abi: AppControllerABI, data });
+    // args = [salt, release]; release.containerPolicy is the 4th tuple field
+    const release = args![1] as { containerPolicy: ContainerPolicy };
+    expect(release.containerPolicy).toEqual(policy);
+  });
+
+  it("keeps the old 3-field selector out of the ABI (drift guard)", () => {
+    expect(() =>
+      // The pre-v1.5.0 3-field Release shape must no longer encode against this ABI.
+      encodeFunctionData({
+        abi: AppControllerABI,
+        functionName: "createApp",
+        args: [
+          SALT,
+          {
+            rmsRelease: { artifacts: [], upgradeByTime: 0 },
+            publicEnv: "0x" as Hex,
+            encryptedEnv: "0x" as Hex,
+            // containerPolicy intentionally omitted -> viem must reject the arity
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/sdk/src/client/common/types/index.ts
+++ b/packages/sdk/src/client/common/types/index.ts
@@ -232,11 +232,21 @@ export interface BillingEnvironmentConfig {
   billingApiServerURL: string;
 }
 
+/**
+ * On-chain AppController ABI version for an environment.
+ * - "v1.4": 3-field Release struct (sepolia, mainnet-alpha)
+ * - "v1.5": 4-field Release struct with containerPolicy (sepolia-dev)
+ * Omitted defaults to the latest ("v1.5") in the contract caller.
+ */
+export type AppControllerAbiVersion = "v1.4" | "v1.5";
+
 export interface EnvironmentConfig {
   name: string;
   build: "dev" | "prod";
   chainID: bigint;
   appControllerAddress: Address;
+  /** Deployed AppController ABI version; selects Release encoding. Defaults to v1.5 when omitted. */
+  releaseAbiVersion?: AppControllerAbiVersion;
   permissionControllerAddress: string;
   erc7702DelegatorAddress: string;
   kmsServerURL: string;

--- a/packages/sdk/src/client/common/types/index.ts
+++ b/packages/sdk/src/client/common/types/index.ts
@@ -248,6 +248,36 @@ export interface EnvironmentConfig {
   baseRPCURL?: string;
 }
 
+export interface EnvVar {
+  key: string;
+  value: string;
+}
+
+/**
+ * Container runtime policy attached to a release (AppController v1.5.0+).
+ *
+ * Added to the on-chain `Release` struct in eigenx-contracts (KMS-006). All
+ * fields are optional knobs over the container's entrypoint/runtime; an empty
+ * policy (see EMPTY_CONTAINER_POLICY) preserves the image's own
+ * CMD/ENTRYPOINT/env.
+ */
+export interface ContainerPolicy {
+  args: string[];
+  cmdOverride: string[];
+  env: EnvVar[];
+  envOverride: EnvVar[];
+  restartPolicy: string;
+}
+
+/** An empty ContainerPolicy — defers entirely to the image defaults. */
+export const EMPTY_CONTAINER_POLICY: ContainerPolicy = {
+  args: [],
+  cmdOverride: [],
+  env: [],
+  envOverride: [],
+  restartPolicy: "",
+};
+
 export interface Release {
   rmsRelease: {
     artifacts: Array<{
@@ -258,6 +288,10 @@ export interface Release {
   };
   publicEnv: Uint8Array; // JSON bytes
   encryptedEnv: Uint8Array; // Encrypted string bytes
+  // Container runtime policy (AppController v1.5.0+ `Release.containerPolicy`).
+  // Optional in the SDK type for backwards-compatible construction; the encoder
+  // substitutes EMPTY_CONTAINER_POLICY when callers omit it.
+  containerPolicy?: ContainerPolicy;
 }
 
 export interface ParsedEnvironment {


### PR DESCRIPTION
Deploys/upgrades on **sepolia-dev** have been failing since the AppController was upgraded to **v1.5.x** (2026-05-28) with an opaque `execution reverted`. **sepolia / mainnet-alpha remain on v1.4.0**, so the fix must support **both** ABIs, selected per environment.

## Root cause

eigenx-contracts **KMS-006** added a 4th field `containerPolicy` to the on-chain `Release` struct on v1.5.x:

```
v1.4.x: Release = (rmsRelease, publicEnv, encryptedEnv)                  // createApp 0xa60daa8f
v1.5.x: Release = (rmsRelease, publicEnv, encryptedEnv, ContainerPolicy) // createApp 0x5e92a19f
```

The SDK shipped only the 3-field ABI. Against v1.5.x (sepolia-dev) it encoded the now-nonexistent `0xa60daa8f` selector → empty-data revert.

Verified on-chain per environment:
| Env | Controller | `version()` | Release |
|---|---|---|---|
| sepolia-dev | `0xa86DC1C…` | 1.5.1 | 4-field |
| sepolia | `0x0dd810a6…` | 1.4.0 | 3-field |
| mainnet-alpha | `0xc38d35Fc…` | 1.4.0 | 3-field |

## Design — support both, select per environment

- Vendor **both** ABIs: `AppController.json` (v1.5) and `AppController.v1_4.json` (v1.4). They also diverge on the `getApps` `AppConfig` shape, so the whole ABI is selected, not just create/upgrade.
- Add `releaseAbiVersion?: "v1.4" | "v1.5"` to `EnvironmentConfig`: **sepolia-dev = v1.5**, **sepolia + mainnet-alpha = v1.4** (omitted defaults to v1.5). Future prod upgrade = one-line config flip.
- `caller.ts`: `appControllerAbiFor(env)` selects the ABI; `releaseForViem(release, env)` adds `containerPolicy` only on v1.5. Add `ContainerPolicy`/`EnvVar` types + `EMPTY_CONTAINER_POLICY` (empty policy preserves the image’s own entrypoint/env; current deploy path supplies none).

## Testing

- [x] Unit: per-version encoding asserts `0xa60daa8f` (v1.4) and `0x5e92a19f` (v1.5), containerPolicy round-trip, and arity guards
- [x] Unit: env→ABI selection through real `getEnvironmentConfig` (sepolia-dev → v1.5, sepolia/mainnet-alpha → v1.4)
- [x] 31 SDK tests pass; `tsc --noEmit` clean; `eslint` clean on changed files
- [x] E2E sepolia-dev (v1.5): deploy created app on-chain, status `STARTED`
- [x] E2E sepolia-prod (v1.4): deploy created app on-chain (tx `0x8dc3c88e…`), status `STARTED` — the case the wholesale-swap approach would have reverted
- [x] Both test apps terminated afterward

### Known follow-on (out of scope)
The bare-`nginx` test image enters **Failed state** during TEE provisioning (off-chain watcher, identical on both envs) — a runtime concern unrelated to this ABI fix.

### Branch target
Targets `release/v1.0.0` as requested. Same drift exists on `master`; forward-port (or re-sync `master` from eigenx-contracts bindings). The new `createEmptyApp` two-step flow is present in the v1.5 ABI but not adopted — this is the minimal fix to keep the existing one-shot `createApp` deploy path valid across both contract versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)