### PR TITLE
Add attested AI Gateway client with automatic Cloudflare failover

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,6 +36,11 @@
       "types": "./dist/attest.d.ts",
       "import": "./dist/attest.js",
       "require": "./dist/attest.cjs"
+    },
+    "./ai": {
+      "types": "./dist/ai.d.ts",
+      "import": "./dist/ai.js",
+      "require": "./dist/ai.cjs"
     }
   },
   "scripts": {

--- a/packages/sdk/src/ai.ts
+++ b/packages/sdk/src/ai.ts
@@ -1,0 +1,8 @@
+/**
+ * AI gateway module entry point
+ *
+ * Import from "@layr-labs/ecloud-sdk/ai" for attested AI gateway requests
+ * from inside EigenCloud compute apps.
+ */
+
+export * from "./client/modules/ai";

--- a/packages/sdk/src/client/modules/ai/index.test.ts
+++ b/packages/sdk/src/client/modules/ai/index.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AiGatewayClient,
+  createAttestedAiGatewayClient,
+  DEFAULT_AI_GATEWAY_BASE_URL,
+} from "./index";
+
+describe("AiGatewayClient", () => {
+  const originalAiGatewayUrl = process.env.ECLOUD_AI_GATEWAY_URL;
+  const originalFallbackUrls = process.env.ECLOUD_AI_GATEWAY_FALLBACK_URLS;
+  const originalKmsServerUrl = process.env.KMS_SERVER_URL;
+  const originalKmsPublicKey = process.env.KMS_PUBLIC_KEY;
+
+  beforeEach(() => {
+    delete process.env.ECLOUD_AI_GATEWAY_URL;
+    delete process.env.ECLOUD_AI_GATEWAY_FALLBACK_URLS;
+    delete process.env.KMS_SERVER_URL;
+    delete process.env.KMS_PUBLIC_KEY;
+  });
+
+  afterEach(() => {
+    restoreEnv("ECLOUD_AI_GATEWAY_URL", originalAiGatewayUrl);
+    restoreEnv("ECLOUD_AI_GATEWAY_FALLBACK_URLS", originalFallbackUrls);
+    restoreEnv("KMS_SERVER_URL", originalKmsServerUrl);
+    restoreEnv("KMS_PUBLIC_KEY", originalKmsPublicKey);
+    vi.restoreAllMocks();
+  });
+
+  it("adds the attestation bearer token to gateway requests", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ data: [] }, { status: 200 }));
+    const client = new AiGatewayClient({
+      tokenProvider: async () => "jwt-token",
+      fetchFn,
+    });
+
+    await client.listModels();
+
+    expect(fetchFn).toHaveBeenCalledWith(`${DEFAULT_AI_GATEWAY_BASE_URL}/v1/models`, {
+      method: "GET",
+      headers: expect.any(Headers),
+    });
+    const headers = fetchFn.mock.calls[0][1].headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer jwt-token");
+  });
+
+  it("does not fail over normal API responses such as JSON 401s", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ error: "invalid token" }, { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse({ data: [] }, { status: 200 }));
+    const client = new AiGatewayClient({
+      tokenProvider: { getToken: async () => "bad-token" },
+      baseUrl: "https://primary.example.com/",
+      fallbackBaseUrls: ["https://fallback.example.com"],
+      fetchFn,
+    });
+
+    await expect(client.listModels()).rejects.toMatchObject({
+      details: { status: 401, contentType: "application/json" },
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn.mock.calls[0][0]).toBe("https://primary.example.com/v1/models");
+  });
+
+  it("fails over Cloudflare transient HTML responses to the next configured base URL", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        htmlResponse("<html><!--[if lt IE 7]>cloudflare</html>", {
+          status: 502,
+          headers: { server: "cloudflare", "cf-ray": "abc-SIN" },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "model-a" }] }, { status: 200 }));
+    const client = new AiGatewayClient({
+      tokenProvider: async () => "jwt-token",
+      baseUrl: "https://primary.example.com",
+      fallbackBaseUrls: ["https://fallback.example.com"],
+      fetchFn,
+    });
+
+    const models = await client.listModels<{ data: Array<{ id: string }> }>();
+
+    expect(models.data[0].id).toBe("model-a");
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn.mock.calls[0][0]).toBe("https://primary.example.com/v1/models");
+    expect(fetchFn.mock.calls[1][0]).toBe("https://fallback.example.com/v1/models");
+  });
+
+  it("reads fallback URLs from ECLOUD_AI_GATEWAY_FALLBACK_URLS", async () => {
+    process.env.ECLOUD_AI_GATEWAY_URL = "https://primary.example.com";
+    process.env.ECLOUD_AI_GATEWAY_FALLBACK_URLS =
+      "https://fallback-a.example.com, https://fallback-b.example.com/";
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        htmlResponse("cloudflare", {
+          status: 502,
+          headers: { server: "cloudflare" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        htmlResponse("cloudflare", {
+          status: 502,
+          headers: { server: "cloudflare" },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, { status: 200 }));
+    const client = new AiGatewayClient({
+      tokenProvider: async () => "jwt-token",
+      fetchFn,
+    });
+
+    await expect(client.listModels()).resolves.toEqual({ ok: true });
+
+    expect(fetchFn.mock.calls.map((call) => call[0])).toEqual([
+      "https://primary.example.com/v1/models",
+      "https://fallback-a.example.com/v1/models",
+      "https://fallback-b.example.com/v1/models",
+    ]);
+  });
+
+  it("throws diagnostics when the final gateway response is not ok", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      htmlResponse("<html><!--[if lt IE 7]>cloudflare error page</html>", {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { server: "cloudflare", "cf-ray": "ray-id-SIN" },
+      }),
+    );
+    const client = new AiGatewayClient({
+      tokenProvider: async () => "jwt-token",
+      fetchFn,
+    });
+
+    await expect(client.listModels()).rejects.toMatchObject({
+      name: "AiGatewayRequestError",
+      message: "AI gateway request failed (502 Bad Gateway). Cloudflare ray: ray-id-SIN.",
+      details: {
+        status: 502,
+        statusText: "Bad Gateway",
+        cfRay: "ray-id-SIN",
+        contentType: "text/html",
+      },
+    });
+  });
+
+  it("posts chat completions with JSON content type", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ choices: [] }, { status: 200 }));
+    const client = new AiGatewayClient({
+      tokenProvider: async () => "jwt-token",
+      fetchFn,
+    });
+    const body = { model: "openai/gpt-4o-mini", messages: [{ role: "user", content: "hi" }] };
+
+    await client.chatCompletions(body);
+
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect((init.headers as Headers).get("Content-Type")).toBe("application/json");
+    expect(init.body).toBe(JSON.stringify(body));
+  });
+
+  it("requires KMS environment when creating an attested gateway client from env", () => {
+    expect(() =>
+      createAttestedAiGatewayClient({ audience: "https://ai-gateway.eigencloud.xyz" }),
+    ).toThrow("KMS_SERVER_URL is required");
+
+    process.env.KMS_SERVER_URL = "http://kms.internal:8080";
+    expect(() =>
+      createAttestedAiGatewayClient({ audience: "https://ai-gateway.eigencloud.xyz" }),
+    ).toThrow("KMS_PUBLIC_KEY is required");
+  });
+});
+
+function jsonResponse(body: unknown, init: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...headersRecord(init.headers) },
+  });
+}
+
+function htmlResponse(body: string, init: ResponseInit): Response {
+  return new Response(body, {
+    ...init,
+    headers: { "content-type": "text/html", ...headersRecord(init.headers) },
+  });
+}
+
+function headersRecord(headers: HeadersInit | undefined): Record<string, string> {
+  return Object.fromEntries(new Headers(headers).entries());
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/packages/sdk/src/client/modules/ai/index.ts
+++ b/packages/sdk/src/client/modules/ai/index.ts
@@ -1,0 +1,237 @@
+import { AttestClient, type AttestClientConfig } from "../attest/attest-client";
+import { JwtProvider } from "../attest/jwt-provider";
+
+export const DEFAULT_AI_GATEWAY_BASE_URL = "https://ai-gateway.eigencloud.xyz";
+
+const CLOUDFLARE_TRANSIENT_STATUSES = new Set([
+  502, 503, 504, 520, 521, 522, 523, 524, 525, 526, 530,
+]);
+
+export type AiGatewayTokenProvider = { getToken: () => Promise<string> } | (() => Promise<string>);
+
+export interface AiGatewayClientConfig {
+  tokenProvider: AiGatewayTokenProvider;
+  baseUrl?: string;
+  fallbackBaseUrls?: string[];
+  fetchFn?: typeof fetch;
+}
+
+export interface AttestedAiGatewayClientConfig
+  extends
+    Omit<AiGatewayClientConfig, "tokenProvider">,
+    Pick<AttestClientConfig, "audience" | "socketPath"> {
+  kmsServerURL?: string;
+  kmsPublicKey?: string;
+  jwtBufferSeconds?: number;
+}
+
+export interface AiGatewayRequestErrorDetails {
+  status?: number;
+  statusText?: string;
+  url: string;
+  cfRay?: string;
+  contentType?: string;
+  bodySnippet?: string;
+}
+
+export class AiGatewayRequestError extends Error {
+  readonly details: AiGatewayRequestErrorDetails;
+
+  constructor(
+    message: string,
+    details: AiGatewayRequestErrorDetails,
+    options?: { cause?: unknown },
+  ) {
+    super(message);
+    this.name = "AiGatewayRequestError";
+    this.details = details;
+    if (options?.cause) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+export class AiGatewayClient {
+  private readonly tokenProvider: AiGatewayTokenProvider;
+  private readonly baseUrls: string[];
+  private readonly fetchFn: typeof fetch;
+
+  constructor(config: AiGatewayClientConfig) {
+    this.tokenProvider = config.tokenProvider;
+    this.baseUrls = resolveBaseUrls(config.baseUrl, config.fallbackBaseUrls);
+    this.fetchFn = config.fetchFn ?? fetch;
+  }
+
+  async fetch(path: string, init: RequestInit = {}): Promise<Response> {
+    const token = await getBearerToken(this.tokenProvider);
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${token}`);
+
+    let lastNetworkError: unknown;
+
+    for (let index = 0; index < this.baseUrls.length; index++) {
+      const url = joinUrl(this.baseUrls[index], path);
+      try {
+        const response = await this.fetchFn(url, { ...init, headers });
+        if (index < this.baseUrls.length - 1 && isCloudflareTransient(response)) {
+          continue;
+        }
+        return response;
+      } catch (error) {
+        lastNetworkError = error;
+        if (index === this.baseUrls.length - 1) {
+          throw new AiGatewayRequestError(
+            `AI gateway request failed before receiving a response: ${errorMessage(error)}`,
+            { url },
+            { cause: error },
+          );
+        }
+      }
+    }
+
+    throw new AiGatewayRequestError(
+      `AI gateway request failed before receiving a response: ${errorMessage(lastNetworkError)}`,
+      { url: joinUrl(this.baseUrls[this.baseUrls.length - 1], path) },
+      { cause: lastNetworkError },
+    );
+  }
+
+  async requestJson<T = unknown>(path: string, init: RequestInit = {}): Promise<T> {
+    const response = await this.fetch(path, init);
+    if (!response.ok) {
+      throw await createResponseError(response);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  async listModels<T = unknown>(init: RequestInit = {}): Promise<T> {
+    return this.requestJson<T>("/v1/models", { ...init, method: init.method ?? "GET" });
+  }
+
+  async chatCompletions<T = unknown>(body: unknown, init: RequestInit = {}): Promise<T> {
+    const headers = new Headers(init.headers);
+    if (!headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+
+    return this.requestJson<T>("/v1/chat/completions", {
+      ...init,
+      method: init.method ?? "POST",
+      headers,
+      body: init.body ?? JSON.stringify(body),
+    });
+  }
+}
+
+export function createAiGatewayClient(config: AiGatewayClientConfig): AiGatewayClient {
+  return new AiGatewayClient(config);
+}
+
+export function createAttestedAiGatewayClient(
+  config: AttestedAiGatewayClientConfig,
+): AiGatewayClient {
+  const kmsServerURL = config.kmsServerURL ?? process.env.KMS_SERVER_URL;
+  const kmsPublicKey = config.kmsPublicKey ?? process.env.KMS_PUBLIC_KEY;
+
+  if (!kmsServerURL) {
+    throw new Error("KMS_SERVER_URL is required to create an attested AI gateway client");
+  }
+  if (!kmsPublicKey) {
+    throw new Error("KMS_PUBLIC_KEY is required to create an attested AI gateway client");
+  }
+
+  const attestClient = new AttestClient({
+    kmsServerURL,
+    kmsPublicKey,
+    audience: config.audience,
+    socketPath: config.socketPath,
+  });
+
+  return new AiGatewayClient({
+    ...config,
+    tokenProvider: new JwtProvider(attestClient, config.jwtBufferSeconds),
+  });
+}
+
+function getBearerToken(provider: AiGatewayTokenProvider): Promise<string> {
+  if (typeof provider === "function") {
+    return provider();
+  }
+  return provider.getToken();
+}
+
+function resolveBaseUrls(baseUrl?: string, fallbackBaseUrls?: string[]): string[] {
+  const primary =
+    normalizeBaseUrl(baseUrl) ??
+    normalizeBaseUrl(readEnv("ECLOUD_AI_GATEWAY_URL")) ??
+    DEFAULT_AI_GATEWAY_BASE_URL;
+  const fallbacks =
+    fallbackBaseUrls ??
+    readEnv("ECLOUD_AI_GATEWAY_FALLBACK_URLS")
+      ?.split(",")
+      .map((value) => value.trim());
+
+  return dedupe([primary, ...(fallbacks ?? [])].map(normalizeBaseUrl).filter(isDefined));
+}
+
+function normalizeBaseUrl(value?: string): string | undefined {
+  const trimmed = value?.trim().replace(/\/+$/, "");
+  return trimmed ? trimmed : undefined;
+}
+
+function readEnv(name: string): string | undefined {
+  return typeof process === "undefined" ? undefined : process.env[name];
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  return `${baseUrl}/${path.replace(/^\/+/, "")}`;
+}
+
+function isCloudflareTransient(response: Response): boolean {
+  if (!CLOUDFLARE_TRANSIENT_STATUSES.has(response.status)) {
+    return false;
+  }
+
+  const server = response.headers.get("server")?.toLowerCase() ?? "";
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  return (
+    server.includes("cloudflare") ||
+    response.headers.has("cf-ray") ||
+    contentType.includes("text/html")
+  );
+}
+
+async function createResponseError(response: Response): Promise<AiGatewayRequestError> {
+  const contentType = response.headers.get("content-type") ?? undefined;
+  const cfRay = response.headers.get("cf-ray") ?? undefined;
+  const bodySnippet = (await response.clone().text()).slice(0, 500);
+  const cloudflareHint =
+    isCloudflareTransient(response) && cfRay ? ` Cloudflare ray: ${cfRay}.` : "";
+
+  return new AiGatewayRequestError(
+    `AI gateway request failed (${response.status} ${response.statusText}).${cloudflareHint}`,
+    {
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url,
+      cfRay,
+      contentType,
+      bodySnippet,
+    },
+  );
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./client/index";
 export * from "./client/modules/attest";
+export * from "./client/modules/ai";

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -15,7 +15,14 @@ const sdkVersion = process.env.PACKAGE_VERSION || packageJson.version || "0.0.0"
 const posthogApiKey = process.env.POSTHOG_API_KEY_BUILD_TIME;
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/compute.ts", "src/billing.ts", "src/browser.ts", "src/attest.ts"],
+  entry: [
+    "src/index.ts",
+    "src/compute.ts",
+    "src/billing.ts",
+    "src/browser.ts",
+    "src/attest.ts",
+    "src/ai.ts",
+  ],
   dts: true,
   format: ["esm", "cjs"],
   clean: true,


### PR DESCRIPTION
## Summary

Fixes #170

This PR introduces an attested AI Gateway client for the EigenCloud SDK, providing authenticated access to the AI Gateway while improving resilience against transient Cloudflare edge failures.

### What's included

- Add `@layr-labs/ecloud-sdk/ai` as a dedicated AI Gateway client
- Support attestation-based Bearer authentication using the existing `AttestClient` and `JwtProvider`
- Add helpers for:
  - `/v1/models`
  - `/v1/chat/completions`
- Automatically detect transient Cloudflare 5xx HTML responses and fail over to configured alternate gateway URLs
- Surface richer diagnostics on failures, including:
  - HTTP status
  - Content-Type
  - Response body snippet
  - `cf-ray` identifier

## Testing

- `pnpm.cmd -C packages/sdk exec vitest run`
- `pnpm.cmd -C packages/sdk run typecheck`
- `pnpm.cmd -C packages/sdk run lint`
- `pnpm.cmd -C packages/sdk run build`